### PR TITLE
feature(config-ui): version bump for material-ui to solve related bugs

### DIFF
--- a/packages/config-ui/package.json
+++ b/packages/config-ui/package.json
@@ -9,8 +9,8 @@
     "test": "./node_modules/.bin/jest"
   },
   "dependencies": {
-    "@material-ui/core": "^1.0.0-rc.1",
-    "@material-ui/icons": "^1.0.0-rc.0",
+    "@material-ui/core": "^1.3.0",
+    "@material-ui/icons": "^1.1.0",
     "@pie-lib/editable-html": "^6.1.1",
     "@pie-lib/icons": "^2.2.0",
     "debug": "^3.0.1",


### PR DESCRIPTION
Once merged, all other packages that depend on @pie-lib/config-ui will need to be updated.

Solves the keyboard input not working on number textfields. (specifically for extended-text-entry)