### PR TITLE
feature(choice-configuration): allow no label mode and adjust feedback input design

### DIFF
--- a/packages/config-ui/src/choice-configuration/__tests__/__snapshots__/index.test.jsx.snap
+++ b/packages/config-ui/src/choice-configuration/__tests__/__snapshots__/index.test.jsx.snap
@@ -9,8 +9,6 @@ exports[`index - snapshot renders correctly 1`] = `
   >
     <div
       className="MuiFormControl-root-4 RawInputContainer-formControl-2"
-      onBlur={[Function]}
-      onFocus={[Function]}
     >
       <label
         className="MuiFormLabel-root-13 MuiInputLabel-root-8 MuiInputLabel-formControl-9 MuiInputLabel-animated-12 MuiInputLabel-shrink-11 RawInputContainer-label-3"
@@ -66,28 +64,45 @@ exports[`index - snapshot renders correctly 1`] = `
       </span>
     </div>
     <div
-      className="MuiFormControl-root-4 RawInputContainer-formControl-2 Component-labelContainer-49"
-      onBlur={[Function]}
-      onFocus={[Function]}
+      className={undefined}
     >
-      <label
-        className="MuiFormLabel-root-13 MuiInputLabel-root-8 MuiInputLabel-formControl-9 MuiInputLabel-animated-12 MuiInputLabel-shrink-11 RawInputContainer-label-3"
-        data-shrink={true}
-      >
-        Label
-      </label>
       <div
-        className="Component-editorHolder-50"
+        className="MuiFormControl-root-4 RawInputContainer-formControl-2 Component-labelContainer-49"
       >
-        <div>
-          EditableHtml
+        <label
+          className="MuiFormLabel-root-13 MuiInputLabel-root-8 MuiInputLabel-formControl-9 MuiInputLabel-animated-12 MuiInputLabel-shrink-11 RawInputContainer-label-3"
+          data-shrink={true}
+        >
+          Label
+        </label>
+        <div
+          className="Component-editorHolder-50"
+        >
+          <div>
+            EditableHtml
+          </div>
+        </div>
+      </div>
+      <div
+        className="MuiFormControl-root-4 RawInputContainer-formControl-2 Component-labelContainer-49 Component-text-51"
+      >
+        <label
+          className="MuiFormLabel-root-13 MuiInputLabel-root-8 MuiInputLabel-formControl-9 MuiInputLabel-animated-12 MuiInputLabel-shrink-11 RawInputContainer-label-3"
+          data-shrink={true}
+        >
+          Feedback Text
+        </label>
+        <div
+          className="Component-editorHolder-50"
+        >
+          <div>
+            EditableHtml
+          </div>
         </div>
       </div>
     </div>
     <div
       className="MuiFormControl-root-4 RawInputContainer-formControl-2"
-      onBlur={[Function]}
-      onFocus={[Function]}
     >
       <label
         className="MuiFormLabel-root-13 MuiInputLabel-root-8 MuiInputLabel-formControl-9 MuiInputLabel-animated-12 MuiInputLabel-shrink-11 RawInputContainer-label-3"
@@ -142,8 +157,6 @@ exports[`index - snapshot renders correctly 1`] = `
     </div>
     <div
       className="MuiFormControl-root-4 RawInputContainer-formControl-2"
-      onBlur={[Function]}
-      onFocus={[Function]}
     >
       <label
         className="MuiFormLabel-root-13 MuiInputLabel-root-8 MuiInputLabel-formControl-9 MuiInputLabel-animated-12 MuiInputLabel-shrink-11 RawInputContainer-label-3"
@@ -190,25 +203,6 @@ exports[`index - snapshot renders correctly 1`] = `
           className="MuiTouchRipple-root-42"
         />
       </button>
-    </div>
-  </div>
-  <div
-    className="MuiFormControl-root-4 RawInputContainer-formControl-2 Component-labelContainer-49 Component-text-55"
-    onBlur={[Function]}
-    onFocus={[Function]}
-  >
-    <label
-      className="MuiFormLabel-root-13 MuiInputLabel-root-8 MuiInputLabel-formControl-9 MuiInputLabel-animated-12 MuiInputLabel-shrink-11 RawInputContainer-label-3"
-      data-shrink={true}
-    >
-      Feedback Text
-    </label>
-    <div
-      className="Component-editorHolder-50"
-    >
-      <div>
-        EditableHtml
-      </div>
     </div>
   </div>
 </div>

--- a/packages/config-ui/src/choice-configuration/index.jsx
+++ b/packages/config-ui/src/choice-configuration/index.jsx
@@ -62,6 +62,8 @@ const Feedback = withStyles(() => ({
 export class ChoiceConfiguration extends React.Component {
   static propTypes = {
     classes: PropTypes.object.isRequired,
+    noLabels: PropTypes.bool,
+    useLetterOrdering: PropTypes.bool,
     className: PropTypes.string,
     mode: PropTypes.oneOf(['checkbox', 'radio']),
     defaultFeedback: PropTypes.object.isRequired,
@@ -84,7 +86,9 @@ export class ChoiceConfiguration extends React.Component {
   };
 
   static defaultProps = {
-    index: -1
+    index: -1,
+    noLabels: false,
+    useLetterOrdering: false
   };
 
   _changeFn = key => update => {
@@ -136,6 +140,8 @@ export class ChoiceConfiguration extends React.Component {
       defaultFeedback,
       index,
       className,
+      noLabels,
+      useLetterOrdering,
       imageSupport
     } = this.props;
 
@@ -146,22 +152,30 @@ export class ChoiceConfiguration extends React.Component {
         <div className={classes.topRow}>
           {index > 0 && (
             <Typography className={classes.index} type="title">
-              {index}
+              {useLetterOrdering ? String.fromCharCode(96 + index).toUpperCase() : index}
             </Typography>
           )}
           <InputToggle
             className={classes.toggle}
             onChange={this.onCheckedChange}
-            label={'Correct'}
+            label={!noLabels ? 'Correct' : ''}
             checked={!!data.correct}
           />
-          <EditableHtmlContainer
-            label={'Label'}
-            value={data.label}
-            onChange={this.onLabelChange}
-            imageSupport={imageSupport}
-          />
-          <InputContainer className={classes.feedback} label="Feedback">
+          <div className={classes.middleColumn}>
+            <EditableHtmlContainer
+              label={!noLabels ? 'Label' : ''}
+              value={data.label}
+              onChange={this.onLabelChange}
+              imageSupport={imageSupport}
+            />
+            <Feedback
+              {...data.feedback}
+              correct={data.correct}
+              defaults={defaultFeedback}
+              onChange={this.onFeedbackValueChange}
+            />
+          </div>
+          <InputContainer className={classes.feedback} label={!noLabels ? 'Feedback' : ''}>
             <FeedbackMenu
               onChange={this.onFeedbackTypeChange}
               value={data.feedback}
@@ -170,7 +184,7 @@ export class ChoiceConfiguration extends React.Component {
               }}
             />
           </InputContainer>
-          <InputContainer className={classes.delete} label="Delete">
+          <InputContainer className={classes.delete} label={!noLabels ? 'Delete' : ''}>
             <IconButton
               aria-label="delete"
               className={classes.deleteIcon}
@@ -180,12 +194,6 @@ export class ChoiceConfiguration extends React.Component {
             </IconButton>
           </InputContainer>
         </div>
-        <Feedback
-          {...data.feedback}
-          correct={data.correct}
-          defaults={defaultFeedback}
-          onChange={this.onFeedbackValueChange}
-        />
       </div>
     );
   }
@@ -231,6 +239,11 @@ const styles = theme => ({
     paddingTop: theme.spacing.unit,
     paddingLeft: 0,
     marginLeft: 0
+  },
+  middleColumn: {
+    display: 'flex',
+    flex: 1,
+    flexDirection: 'column'
   }
 });
 


### PR DESCRIPTION
`noLabels` - no labels will be presented anywhere.
`useLetterOrdering` - instead of number ordering, choices will be listed alphabetically.

Also, the feedback input was positioned a little differently, more in-line with what the corespring version looks like.

Before:

![image](https://user-images.githubusercontent.com/4669986/42219585-17d89de8-7ed5-11e8-847e-8d5f73440563.png)


After:

![image](https://user-images.githubusercontent.com/4669986/42219554-f65739c2-7ed4-11e8-8f0d-7ce576551767.png)

CC: @evaneus 
