### PR TITLE
feat(editable-html): added slate plugin for soft linebreaks

### DIFF
--- a/packages/editable-html/package.json
+++ b/packages/editable-html/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pie-lib/editable-html",
-  "version": "6.7.0",
+  "version": "6.6.7",
   "description": "",
   "license": "ISC",
   "main": "lib/index.js",

--- a/packages/editable-html/package.json
+++ b/packages/editable-html/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pie-lib/editable-html",
-  "version": "6.6.7",
+  "version": "6.7.0",
   "description": "",
   "license": "ISC",
   "main": "lib/index.js",
@@ -22,12 +22,13 @@
     "react-attr-converter": "^0.3.1",
     "react-jss": "^8.6.1",
     "react-portal": "^4.1.5",
-    "slate": "^0.36.2",
+    "slate": "^0.40.2",
     "slate-edit-list": "^0.11.3",
     "slate-edit-table": "^0.17.0",
     "slate-html-serializer": "^0.6.12",
     "slate-prop-types": "^0.4.38",
     "slate-react": "^0.14.3",
+    "slate-soft-break": "^0.8.1",
     "to-style": "^1.3.3"
   },
   "devDependencies": {

--- a/packages/editable-html/src/plugins/index.jsx
+++ b/packages/editable-html/src/plugins/index.jsx
@@ -10,6 +10,7 @@ import Strikethrough from '@material-ui/icons/FormatStrikethrough';
 import ToolbarPlugin from './toolbar';
 import Underline from '@material-ui/icons/FormatUnderlined';
 import compact from 'lodash/compact';
+import SoftBreakPlugin from 'slate-soft-break';
 import debug from 'debug';
 import List from './list';
 import TablePlugin from './table';
@@ -107,6 +108,7 @@ export const buildPlugins = (activePlugins, opts) => {
       'numbered-list',
       List({ key: 'n', type: 'ol_list', icon: <NumberedListIcon /> })
     ),
-    ToolbarPlugin(opts.toolbar)
+    ToolbarPlugin(opts.toolbar),
+    SoftBreakPlugin(),
   ]);
 };

--- a/packages/editable-html/src/serialization.jsx
+++ b/packages/editable-html/src/serialization.jsx
@@ -179,14 +179,14 @@ function defaultParseHtml(html) {
     null
   );
   var n = textNodes.nextNode();
-  
+
   while(n){
     if(allWhitespace(n) || n.nodeValue === '\u200B'){
       n.parentNode.removeChild(n);
     }
     n = textNodes.nextNode();
   }
-  
+
   return body;
 }
 


### PR DESCRIPTION
Solves https://github.com/pie-framework/pie-elements/issues/77.

All packages that depend on editable-html will need the version bump though in order to benefit from this plugin.