### PR TITLE
fix(editablehtml): fixed auto resizing

### DIFF
--- a/packages/editable-html/src/plugins/toolbar/editor-and-toolbar.jsx
+++ b/packages/editable-html/src/plugins/toolbar/editor-and-toolbar.jsx
@@ -89,8 +89,7 @@ const style = {
     }
   },
   children: {
-    padding: '7px',
-    height: '100%'
+    padding: '7px'
   },
   editorHolder: {
     position: 'relative',


### PR DESCRIPTION
it seems like when an EditableHtml element is a top level children of an InputContainer it resizes until the maximum height on mouseOver and onMouseOut. This can be fixed either by having a wrapper for the EditableHtml component or by this PR.