### PR TITLE
fix(text-select): 

### DIFF
--- a/packages/text-select/src/correctness-token.jsx
+++ b/packages/text-select/src/correctness-token.jsx
@@ -7,9 +7,10 @@ import green from '@material-ui/core/colors/green';
 import orange from '@material-ui/core/colors/orange';
 
 const CorrectnessToken = props => {
-  const { classes } = props;
+  const { classes, index } = props;
 
   const className = classNames(
+    'spanWrapper',
     classes.custom,
     props.correct === true && classes.correct,
     props.correct === false && classes.incorrect
@@ -19,6 +20,7 @@ const CorrectnessToken = props => {
     <span
       className={className}
       dangerouslySetInnerHTML={{ __html: props.text }}
+      data-indexkey={index}
     />
   );
 };

--- a/packages/text-select/src/text-select.jsx
+++ b/packages/text-select/src/text-select.jsx
@@ -58,7 +58,7 @@ export default class TextSelect extends React.Component {
         ...t,
         selectable: !disabled && t.predefined,
         selected,
-        correct
+        correct,
       };
     });
 
@@ -76,6 +76,7 @@ export default class TextSelect extends React.Component {
         onChange={this.change}
         maxNoOfSelections={maxNoOfSelections}
         tokenComponent={tokensHaveCorrectInfo ? CorrectnessToken : undefined}
+        showCorrectnessToken={tokensHaveCorrectInfo}
       />
     );
   }

--- a/packages/text-select/src/token-select/token.jsx
+++ b/packages/text-select/src/token-select/token.jsx
@@ -13,9 +13,8 @@ export class Token extends React.Component {
     ...TokenTypes,
     classes: PropTypes.object.isRequired,
     className: PropTypes.string,
-    onClick: PropTypes.func.isRequired,
     disabled: PropTypes.bool,
-    highlight: PropTypes.bool
+    highlight: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -24,16 +23,17 @@ export class Token extends React.Component {
 
   render() {
     const {
-      onClick,
       text,
       selectable,
       selected,
       classes,
       className: classNameProp,
       disabled,
+      index,
       highlight
     } = this.props;
     const className = classNames(
+      'spanWrapper',
       classes.token,
       disabled && classes.disabled,
       selectable && !disabled && classes.selectable,
@@ -44,9 +44,9 @@ export class Token extends React.Component {
     );
     return (
       <span
-        onClick={selectable && !disabled ? onClick : undefined}
         className={className}
         dangerouslySetInnerHTML={{ __html: text }}
+        data-indexkey={index}
       />
     );
   }


### PR DESCRIPTION
Making use of span wrapper for tokens only where needed and recreated the html as string (issue: previous implementation was breaking the html content).