### PR TITLE
fix: fix bounded drag calculation

### DIFF
--- a/packages/demo/pages/graphing/demo-data.js
+++ b/packages/demo/pages/graphing/demo-data.js
@@ -4,7 +4,7 @@ const fromTo = (fx, fy, tx, ty) => ({ from: xy(fx, fy), to: xy(tx, ty) });
 export const marks = [
   //{ type: 'parabola', root: { x: 0, y: 0 }, edge: { x: 1, y: 1 } },
   // { type: 'parabola', root: { x: 2, y: 2 }, edge: { x: -1, y: 1 } },
-  { type: 'sine', root: xy(-5, 0), edge: xy(-4, 1) },
+  //{ type: 'sine', root: xy(-5, 0), edge: xy(-4, 1) },
   // {
   //   disabled: true,
   //   type: 'polygon',
@@ -105,9 +105,9 @@ export const marks = [
   //   points: [xy(-1, 1), xy(4, 2), xy(5, -3), xy(-1, -2)]
   // }
   // { type: 'line', from: { x: 0, y: 0 }, to: { x: 1, y: 1 } },
-  { type: 'segment', ...fromTo(1, 2, 3, 3) }
+  //  { type: 'segment', ...fromTo(1, 2, 3, 3) }
   // { type: 'ray', ...fromTo(1, -1, -2, -2) },
-  // { type: 'vector', ...fromTo(-1, 1, 2, 2) }
+  { type: 'vector', ...fromTo(0, 0, -5, 5) }
   // { type: 'point', x: 1, y: 1 },
   // {
   //   type: 'circle',

--- a/packages/graphing/src/__tests__/__snapshots__/graph.test.jsx.snap
+++ b/packages/graphing/src/__tests__/__snapshots__/graph.test.jsx.snap
@@ -9,6 +9,7 @@ exports[`Graph snapshot renders 1`] = `
         "min": 0,
         "step": 1,
       },
+      "getRootNode": [Function],
       "range": Object {
         "max": 1,
         "min": 0,
@@ -29,6 +30,7 @@ exports[`Graph snapshot renders 1`] = `
     }
   }
   onMouseMove={[Function]}
+  rootRef={[Function]}
 >
   <WithStyles(Grid)
     graphProps={
@@ -38,6 +40,7 @@ exports[`Graph snapshot renders 1`] = `
           "min": 0,
           "step": 1,
         },
+        "getRootNode": [Function],
         "range": Object {
           "max": 1,
           "min": 0,
@@ -66,6 +69,7 @@ exports[`Graph snapshot renders 1`] = `
           "min": 0,
           "step": 1,
         },
+        "getRootNode": [Function],
         "range": Object {
           "max": 1,
           "min": 0,
@@ -95,6 +99,7 @@ exports[`Graph snapshot renders 1`] = `
           "min": 0,
           "step": 1,
         },
+        "getRootNode": [Function],
         "range": Object {
           "max": 1,
           "min": 0,
@@ -126,6 +131,7 @@ exports[`Graph snapshot renders 1`] = `
           "min": 0,
           "step": 1,
         },
+        "getRootNode": [Function],
         "range": Object {
           "max": 1,
           "min": 0,

--- a/packages/graphing/src/graph.jsx
+++ b/packages/graphing/src/graph.jsx
@@ -214,7 +214,7 @@ export class Graph extends React.Component {
     const tool = this.getTool();
     log('[render]', marks);
 
-    const graphProps = createGraphProps(domain, range, size);
+    const graphProps = createGraphProps(domain, range, size, () => this.rootNode);
     const maskSize = {
       x: -10,
       y: -10,
@@ -224,7 +224,12 @@ export class Graph extends React.Component {
     const common = { graphProps, labelModeEnabled };
 
     return (
-      <Root title={title} onMouseMove={this.mouseMove} {...common}>
+      <Root
+        title={title}
+        onMouseMove={this.mouseMove}
+        rootRef={r => (this.rootNode = r)}
+        {...common}
+      >
         <Grid {...common} />
         <Axes {...axesSettings} {...common} />
         <Bg {...size} onClick={this.onBgClick} {...common} />

--- a/packages/graphing/src/tools/shared/line/index.jsx
+++ b/packages/graphing/src/tools/shared/line/index.jsx
@@ -121,6 +121,7 @@ export const lineBase = (Comp, opts) => {
     };
 
     dragTo = to => {
+      console.log('DRAG TO:', to);
       const { onChange } = this.props;
       onChange({ from: this.props.from, to });
     };

--- a/packages/plot/src/__tests__/__snapshots__/grid-draggable.test.jsx.snap
+++ b/packages/plot/src/__tests__/__snapshots__/grid-draggable.test.jsx.snap
@@ -21,6 +21,7 @@ exports[`gridDraggable snapshot reqular 1`] = `
           "max": 1,
           "min": 0,
         },
+        "getRootNode": [Function],
         "range": Object {
           "max": 1,
           "min": 0,

--- a/packages/plot/src/__tests__/grid-draggable.test.jsx
+++ b/packages/plot/src/__tests__/grid-draggable.test.jsx
@@ -42,7 +42,8 @@ const getGraphProps = () => ({
   size: {
     width: 500,
     height: 500
-  }
+  },
+  getRootNode: () => ({})
 });
 
 describe('gridDraggable', () => {

--- a/packages/plot/src/graph-props.js
+++ b/packages/plot/src/graph-props.js
@@ -2,7 +2,7 @@ import invariant from 'invariant';
 import { buildSizeArray, snapTo } from './utils';
 import { scaleLinear } from 'd3-scale';
 
-export const create = (domain, range, size) => {
+export const create = (domain, range, size, getRootNode) => {
   invariant(domain.min < domain.max, 'domain: min must be less than max');
   invariant(range.min < range.max, 'range: min must be less than max');
 
@@ -23,5 +23,5 @@ export const create = (domain, range, size) => {
     y: snapTo.bind(null, range.min, range.max, 1)
   };
 
-  return { scale, snap, domain, range, size };
+  return { scale, snap, domain, range, size, getRootNode };
 };

--- a/packages/plot/src/grid-draggable.jsx
+++ b/packages/plot/src/grid-draggable.jsx
@@ -102,26 +102,15 @@ export const gridDraggable = opts => Comp => {
 
     skipDragOutsideOfBounds = (dd, e, graphProps) => {
       // ignore drag movement outside of the domain and range.
-      const [rawX, rawY] = clientPoint(dd.node, e);
+      const rootNode = graphProps.getRootNode();
+      const [rawX, rawY] = clientPoint(rootNode, e);
       const { scale, domain, range } = graphProps;
       let x = scale.x.invert(rawX);
       let y = scale.y.invert(rawY);
 
-      if (dd.deltaX > 0 && x < domain.min) {
-        return true;
-      }
-
-      if (dd.deltaX < 0 && x > domain.max) {
-        return true;
-      }
-
-      if (dd.deltaY > 0 && y > range.max) {
-        return true;
-      }
-      if (dd.deltaY < 0 && y < range.min) {
-        return true;
-      }
-      return false;
+      const xOutside = (dd.deltaX > 0 && x < domain.min) || (dd.deltaX < 0 && x > domain.max);
+      const yOutside = (dd.deltaY > 0 && y > range.max) || (dd.deltaY < 0 && y < range.min);
+      return xOutside || yOutside;
     };
 
     onDrag = (e, dd) => {
@@ -136,6 +125,7 @@ export const gridDraggable = opts => Comp => {
       if (dd.deltaX < 0 && dd.deltaX < bounds.left) {
         return;
       }
+
       if (dd.deltaX > 0 && dd.deltaX > bounds.right) {
         return;
       }

--- a/packages/plot/src/root.jsx
+++ b/packages/plot/src/root.jsx
@@ -23,7 +23,8 @@ export class Root extends React.Component {
     children: ChildrenType,
     graphProps: GraphPropsType.isRequired,
     onMouseMove: PropTypes.func,
-    classes: PropTypes.object.isRequired
+    classes: PropTypes.object.isRequired,
+    rootRef: PropTypes.func
   };
 
   mouseMove = g => {
@@ -57,10 +58,9 @@ export class Root extends React.Component {
   }
 
   render() {
-    const { graphProps, children, classes, title } = this.props;
+    const { graphProps, children, classes, title, rootRef } = this.props;
     const { size } = graphProps;
     const padding = 50;
-
     const finalWidth = size.width + padding * 2;
     const finalHeight = size.height + padding * 2;
 
@@ -69,7 +69,12 @@ export class Root extends React.Component {
         {title && <GraphTitle value={title} />}
         <svg width={finalWidth} height={finalHeight} className={classes.svg}>
           <g
-            ref={r => (this.g = r)}
+            ref={r => {
+              this.g = r;
+              if (rootRef) {
+                rootRef(r);
+              }
+            }}
             className={classes.graphBox}
             transform={`translate(${padding}, ${padding})`}
           >


### PR DESCRIPTION
To get the correct x/y coordinates the drag logic needs a reference to
the root <g> node that contains all the elements.