### PR TITLE
Bug fixes.

### DIFF
--- a/packages/demo/pages/graphing/demo-data.js
+++ b/packages/demo/pages/graphing/demo-data.js
@@ -107,7 +107,7 @@ export const marks = [
   // { type: 'line', from: { x: 0, y: 0 }, to: { x: 1, y: 1 } },
   //  { type: 'segment', ...fromTo(1, 2, 3, 3) }
   // { type: 'ray', ...fromTo(1, -1, -2, -2) },
-  { type: 'vector', ...fromTo(0, 0, -5, 5) }
+  // { type: 'vector', ...fromTo(0, 0, -5, 5) }
   // { type: 'point', x: 1, y: 1 },
   // {
   //   type: 'circle',

--- a/packages/demo/pages/graphing/index.js
+++ b/packages/demo/pages/graphing/index.js
@@ -264,6 +264,7 @@ export class GridDemo extends React.PureComponent {
     this.state = {
       currentTool: toolsArr[2],
       tools: toolsArr,
+      displayedTools: toolsArr,
       settings: {
         includeArrows: true,
         labels: true,
@@ -372,6 +373,7 @@ export class GridDemo extends React.PureComponent {
               marks={model.marks}
               backgroundMarks={model.backgroundMarks}
               onChangeMarks={this.changeMarks}
+              displayedTools={this.state.displayedTools}
               tools={this.state.tools}
               currentTool={this.state.currentTool}
               defaultTool={this.state.tools[0].type}

--- a/packages/graphing/src/axis/axes.jsx
+++ b/packages/graphing/src/axis/axes.jsx
@@ -124,11 +124,13 @@ export class RawYAxis extends React.Component {
           tickLength={10}
           tickClassName={classes.tick}
           tickLabelProps={value => {
+            const digits = value.toLocaleString().length || 1;
             const show = value % range.labelStep === 0;
+
             return {
               ...tickLabelStyles,
               dy: 4,
-              dx: -15,
+              dx: -10 - digits * 5,
               opacity: show ? 1 : 0
             };
           }}

--- a/packages/graphing/src/graph-with-controls.jsx
+++ b/packages/graphing/src/graph-with-controls.jsx
@@ -43,7 +43,8 @@ export class GraphWithControls extends React.Component {
       onUndo,
       onRedo,
       onReset,
-      tools
+      tools,
+      displayedTools
     } = this.props;
 
     const { currentTool, labelModeEnabled } = this.state;
@@ -51,7 +52,7 @@ export class GraphWithControls extends React.Component {
       <div className={classNames(classes.graphWithControls, className)}>
         <div className={classes.controls}>
           <ToolMenu
-            tools={tools}
+            tools={displayedTools || tools}
             currentTool={currentTool}
             onChange={this.changeCurrentTool}
             labelModeEnabled={labelModeEnabled}

--- a/packages/graphing/src/labels.jsx
+++ b/packages/graphing/src/labels.jsx
@@ -40,16 +40,9 @@ class RawLabel extends React.Component {
   render() {
     const { text, side, graphProps } = this.props;
 
-    const { scale, range, domain, size } = graphProps;
+    const { size } = graphProps;
 
-    const transform = getTransform(
-      side,
-      scale,
-      range,
-      domain,
-      size.width,
-      size.height
-    );
+    const transform = getTransform(side, size.width, size.height);
     return (
       <text textAnchor="middle" x={0} y={0} transform={transform}>
         {text}
@@ -79,18 +72,20 @@ export class Labels extends React.Component {
 
   static defaultProps = {};
   render() {
-    const { value } = this.props;
+    const { value, graphProps } = this.props;
     return (
       <React.Fragment>
         {value && value.left && (
-          <Label key="left" side="left" text={value.left} />
+          <Label key="left" side="left" text={value.left} graphProps={graphProps} />
         )}
-        {value && value.top && <Label key="top" side="top" text={value.top} />}
+        {value && value.top && (
+          <Label key="top" side="top" text={value.top} graphProps={graphProps} />
+        )}
         {value && value.bottom && (
-          <Label key="bottom" side="bottom" text={value.bottom} />
+          <Label key="bottom" side="bottom" text={value.bottom} graphProps={graphProps} />
         )}
         {value && value.right && (
-          <Label key="right" side="right" text={value.right} />
+          <Label key="right" side="right" text={value.right} graphProps={graphProps} />
         )}
       </React.Fragment>
     );

--- a/packages/graphing/src/tools/circle/__tests__/component.test.jsx
+++ b/packages/graphing/src/tools/circle/__tests__/component.test.jsx
@@ -13,8 +13,8 @@ describe('Component', () => {
       className: 'className',
       onChange,
       graphProps: graphProps(),
-      root: xy(0, 0),
-      edge: xy(1, 1)
+      from: xy(0, 0),
+      to: xy(1, 1)
     };
     const props = { ...defaults, ...extras };
     return shallow(<RawBaseCircle {...props} />);
@@ -28,23 +28,29 @@ describe('Component', () => {
   describe('logic', () => {
     beforeEach(() => (w = wrapper()));
 
-    describe('dragRoot', () => {
+    describe('dragFrom', () => {
       it('calls onChange', () => {
         w = wrapper();
-        w.instance().dragRoot(xy(1, 1));
+        w.instance().dragFrom(xy(1, 1));
+        expect(onChange).not.toHaveBeenCalledWith({
+          from: xy(1, 1),
+          to: xy(1, 1)
+        });
+
+        w.instance().dragFrom(xy(2, 2));
         expect(onChange).toHaveBeenCalledWith({
-          root: xy(1, 1),
-          edge: xy(1, 1)
+          from: xy(2, 2),
+          to: xy(1, 1)
         });
       });
     });
 
-    describe('dragEdge', () => {
+    describe('dragTo', () => {
       it('calls onChange', () => {
-        w.instance().dragEdge(xy(4, 4));
+        w.instance().dragTo(xy(4, 4));
         expect(onChange).toHaveBeenCalledWith({
-          root: xy(0, 0),
-          edge: xy(4, 4)
+          from: xy(0, 0),
+          to: xy(4, 4)
         });
       });
     });
@@ -53,8 +59,8 @@ describe('Component', () => {
       it('calls onChange', () => {
         w.instance().dragCircle(xy(1, 1));
         expect(onChange).toHaveBeenCalledWith({
-          root: xy(1, 1),
-          edge: xy(2, 2)
+          from: xy(1, 1),
+          to: xy(2, 2)
         });
       });
     });

--- a/packages/graphing/src/tools/circle/index.js
+++ b/packages/graphing/src/tools/circle/index.js
@@ -1,4 +1,5 @@
 import Circle from './component';
+import isEqual from 'lodash/isEqual';
 
 export const tool = opts => ({
   type: 'circle',
@@ -7,6 +8,10 @@ export const tool = opts => ({
     return { ...mark, edge: point };
   },
   addPoint: (point, mark) => {
+    if (mark && isEqual(mark.root, point)) {
+      return mark;
+    }
+
     if (!mark) {
       return {
         type: 'circle',

--- a/packages/graphing/src/tools/line/__tests__/__snapshots__/component.test.jsx.snap
+++ b/packages/graphing/src/tools/line/__tests__/__snapshots__/component.test.jsx.snap
@@ -4,15 +4,16 @@ exports[`ArrowedLine snapshot renders 1`] = `
 <g>
   <defs>
     <ArrowMarker
-      id="1"
+      className=""
+      id="1-enabled"
       size={5}
     />
   </defs>
   <line
     className="className"
-    markerEnd="url(#1)"
+    markerEnd="url(#1-enabled)"
     markerId="1"
-    markerStart="url(#1)"
+    markerStart="url(#1-enabled)"
     onChange={[MockFunction]}
   />
 </g>

--- a/packages/graphing/src/tools/line/component.jsx
+++ b/packages/graphing/src/tools/line/component.jsx
@@ -10,16 +10,27 @@ const markerId = genUid();
 
 const lineStyles = theme => ({
   line: styles.line(theme),
-  arrow: styles.arrow(theme)
+  enabledArrow: styles.arrow(theme),
+  disabledArrow: styles.disabledArrow(theme),
+  disabled: styles.disabled(theme),
+  correct: styles.correct(theme, 'stroke'),
+  correctArrow: styles.correct(theme),
+  incorrect: styles.incorrect(theme, 'stroke'),
+  incorrectArrow: styles.incorrect(theme)
 });
 export const ArrowedLine = props => {
   const { className, classes, correctness, disabled, graphProps, from, to, ...rest } = props;
   const { scale } = graphProps;
   const [eFrom, eTo] = trig.edges(graphProps.domain, graphProps.range)(from, to);
+  const suffix = correctness || (disabled && 'disabled') || 'enabled';
+
   return (
     <g>
       <defs>
-        <ArrowMarker id={props.markerId || markerId} className={classes.arrow} />
+        <ArrowMarker
+          id={`${props.markerId || markerId}-${suffix}`}
+          className={classNames(classes[`${suffix}Arrow`])}
+        />
       </defs>
       <line
         x1={scale.x(eFrom.x)}
@@ -32,8 +43,8 @@ export const ArrowedLine = props => {
           classes[correctness],
           className
         )}
-        markerEnd={`url(#${props.markerId || markerId})`}
-        markerStart={`url(#${props.markerId || markerId})`}
+        markerEnd={`url(#${props.markerId || markerId}-${suffix})`}
+        markerStart={`url(#${props.markerId || markerId}-${suffix})`}
         {...rest}
       />
     </g>

--- a/packages/graphing/src/tools/parabola/index.js
+++ b/packages/graphing/src/tools/parabola/index.js
@@ -1,5 +1,6 @@
 import Parabola from './component';
 import debug from 'debug';
+import isEqual from 'lodash/isEqual';
 
 const log = debug('pie-lib:graphing:parabola');
 
@@ -9,6 +10,10 @@ export const tool = () => ({
   complete: (data, mark) => ({ ...mark, building: false, closed: true }),
   addPoint: (point, mark) => {
     log('add point to parabola model: ', point, 'mark: ', mark);
+    if (mark && isEqual(mark.root, point)) {
+      return mark;
+    }
+
     if (!mark) {
       return {
         type: 'parabola',

--- a/packages/graphing/src/tools/point/component.jsx
+++ b/packages/graphing/src/tools/point/component.jsx
@@ -60,13 +60,15 @@ export class Point extends React.Component {
   };
 
   clickPoint = () => {
-    const { labelModeEnabled, onChange } = this.props;
+    const { labelModeEnabled, onChange, onClick, mark } = this.props;
 
     if (labelModeEnabled) {
       onChange(this.props.mark, { ...this.props.mark, label: '' });
       if (this.input) {
         this.input.focus();
       }
+    } else {
+      onClick(mark);
     }
   };
 

--- a/packages/graphing/src/tools/polygon/__tests__/__snapshots__/line.test.jsx.snap
+++ b/packages/graphing/src/tools/polygon/__tests__/__snapshots__/line.test.jsx.snap
@@ -5,7 +5,9 @@ exports[`Line snapshot renders 1`] = `
   className="className"
   classes={
     Object {
+      "correct": "RawLine-correct-3",
       "disabled": "RawLine-disabled-2",
+      "incorrect": "RawLine-incorrect-4",
       "line": "RawLine-line-1",
     }
   }

--- a/packages/graphing/src/tools/polygon/__tests__/__snapshots__/polygon.test.jsx.snap
+++ b/packages/graphing/src/tools/polygon/__tests__/__snapshots__/polygon.test.jsx.snap
@@ -6,7 +6,9 @@ exports[`Polygon snapshot renders 1`] = `
   classes={
     Object {
       "closed": "RawPolygon-closed-1",
+      "correct": "RawPolygon-correct-4",
       "disabled": "RawPolygon-disabled-3",
+      "incorrect": "RawPolygon-incorrect-5",
       "open": "RawPolygon-open-2",
     }
   }

--- a/packages/graphing/src/tools/polygon/component.jsx
+++ b/packages/graphing/src/tools/polygon/component.jsx
@@ -24,8 +24,7 @@ export const buildLines = (points, closed) => {
   }, []);
 
   const all = chunk(expanded, 2).map(([from, to]) => {
-    const line = { from, to };
-    return line;
+    return { from, to };
   });
 
   return closed ? all : initial(all);
@@ -59,6 +58,7 @@ export class RawBaseComponent extends React.Component {
     classes: PropTypes.object,
     className: PropTypes.string,
     disabled: PropTypes.bool,
+    correctness: PropTypes.string,
     points: PropTypes.arrayOf(types.PointType),
     closed: PropTypes.bool,
     onChange: PropTypes.func.isRequired,
@@ -115,9 +115,18 @@ export class RawBaseComponent extends React.Component {
   };
 
   render() {
-    const { closed, disabled, graphProps, onClick, onDragStart, onDragStop, points } = this.props;
+    const {
+      closed,
+      disabled,
+      graphProps,
+      onClick,
+      onDragStart,
+      onDragStop,
+      points,
+      correctness
+    } = this.props;
     const lines = buildLines(points, closed);
-    const common = { onDragStart, onDragStop, graphProps, disabled };
+    const common = { onDragStart, onDragStop, graphProps, disabled, correctness };
     return (
       <g>
         {closed ? (
@@ -159,7 +168,7 @@ export class RawBaseComponent extends React.Component {
   }
 }
 
-export const BaseComponent = withStyles(theme => ({}))(RawBaseComponent);
+export const BaseComponent = withStyles(() => ({}))(RawBaseComponent);
 
 export default class Component extends React.Component {
   static propTypes = {
@@ -206,9 +215,11 @@ export default class Component extends React.Component {
   };
   render() {
     const { mark, graphProps, onClick, isToolActive } = this.props;
+    const { mark: stateMark } = this.state;
+
     return (
       <BaseComponent
-        {...this.state.mark || mark}
+        {...(stateMark || mark)}
         onChange={this.change}
         onClosePolygon={this.closePolygon}
         onDragStart={this.dragStart}

--- a/packages/graphing/src/tools/polygon/line.jsx
+++ b/packages/graphing/src/tools/polygon/line.jsx
@@ -5,7 +5,7 @@ import { PointType } from '../shared/types';
 import { types, gridDraggable } from '@pie-lib/plot';
 import * as utils from '../../utils';
 import classNames from 'classnames';
-import { disabled } from '../shared/styles';
+import { correct, disabled, incorrect } from '../shared/styles';
 
 class RawLine extends React.Component {
   static propTypes = {
@@ -18,7 +18,7 @@ class RawLine extends React.Component {
   };
 
   render() {
-    const { graphProps, classes, from, to, className, disabled, ...rest } = this.props;
+    const { graphProps, classes, from, to, className, disabled, correctness, ...rest } = this.props;
     const { scale } = graphProps;
     return (
       <line
@@ -26,7 +26,12 @@ class RawLine extends React.Component {
         y1={scale.y(from.y)}
         x2={scale.x(to.x)}
         y2={scale.y(to.y)}
-        className={classNames(classes.line, disabled && classes.disabled, className)}
+        className={classNames(
+          classes.line,
+          disabled && classes.disabled,
+          className,
+          classes[correctness]
+        )}
         {...rest}
       />
     );
@@ -46,7 +51,9 @@ export const Line = withStyles(theme => ({
   disabled: {
     ...disabled('stroke'),
     strokeWidth: 2
-  }
+  },
+  correct: correct('stoke'),
+  incorrect: incorrect('stroke')
 }))(RawLine);
 
 export default gridDraggable({

--- a/packages/graphing/src/tools/polygon/polygon.jsx
+++ b/packages/graphing/src/tools/polygon/polygon.jsx
@@ -6,7 +6,7 @@ import { gridDraggable, types } from '@pie-lib/plot';
 import * as utils from '../../utils';
 import classNames from 'classnames';
 import { fade } from '@material-ui/core/styles/colorManipulator';
-import { disabled } from '../shared/styles';
+import { correct, disabled, incorrect } from '../shared/styles';
 
 export const getPointString = (points, scale) => {
   return (points || [])
@@ -31,7 +31,16 @@ export class RawPolygon extends React.Component {
   };
 
   render() {
-    const { points, classes, className, disabled, graphProps, closed, ...rest } = this.props;
+    const {
+      points,
+      classes,
+      className,
+      disabled,
+      correctness,
+      graphProps,
+      closed,
+      ...rest
+    } = this.props;
     const { scale } = graphProps;
 
     const pointString = getPointString(points, scale);
@@ -43,6 +52,7 @@ export class RawPolygon extends React.Component {
           closed && classes.closed,
           !closed && classes.open,
           disabled && classes.disabled,
+          classes[correctness],
           className
         )}
         {...rest}
@@ -64,7 +74,9 @@ export const Polygon = withStyles(theme => ({
   },
   disabled: {
     ...disabled('stroke')
-  }
+  },
+  correct: correct('stoke'),
+  incorrect: incorrect('stroke')
 }))(RawPolygon);
 
 export default gridDraggable({

--- a/packages/graphing/src/tools/ray/__tests__/__snapshots__/component.test.jsx.snap
+++ b/packages/graphing/src/tools/ray/__tests__/__snapshots__/component.test.jsx.snap
@@ -4,13 +4,14 @@ exports[`RayLine snapshot renders 1`] = `
 <g>
   <defs>
     <ArrowMarker
-      id="1"
+      className=""
+      id="1-enabled"
       size={5}
     />
   </defs>
   <line
     className="className"
-    markerEnd="url(#1)"
+    markerEnd="url(#1-enabled)"
     markerId="1"
     onChange={[MockFunction]}
     x1={0}

--- a/packages/graphing/src/tools/ray/component.jsx
+++ b/packages/graphing/src/tools/ray/component.jsx
@@ -13,17 +13,27 @@ const markerId = genUid();
 
 const rayStyles = theme => ({
   line: styles.line(theme),
-  arrow: styles.arrow(theme)
+  enabledArrow: styles.arrow(theme),
+  disabledArrow: styles.disabledArrow(theme),
+  disabled: styles.disabled(theme),
+  correct: styles.correct(theme, 'stroke'),
+  correctArrow: styles.correct(theme),
+  incorrect: styles.incorrect(theme, 'stroke'),
+  incorrectArrow: styles.incorrect(theme)
 });
 export const RayLine = props => {
   const { graphProps, from, to, classes, disabled, correctness, className, ...rest } = props;
   const { scale } = graphProps;
   const [aToB] = trig.edges(graphProps.domain, graphProps.range)(from, to);
+  const suffix = correctness || (disabled && 'disabled') || 'enabled';
 
   return (
     <g>
       <defs>
-        <ArrowMarker id={props.markerId || markerId} className={classes.arrow} />
+        <ArrowMarker
+          id={`${props.markerId || markerId}-${suffix}`}
+          className={classNames(classes[`${suffix}Arrow`])}
+        />
       </defs>
       <line
         x1={scale.x(from.x)}
@@ -37,7 +47,7 @@ export const RayLine = props => {
           classes[correctness],
           className
         )}
-        markerEnd={`url(#${props.markerId || markerId})`}
+        markerEnd={`url(#${props.markerId || markerId}-${suffix})`}
       />
     </g>
   );

--- a/packages/graphing/src/tools/segment/component.jsx
+++ b/packages/graphing/src/tools/segment/component.jsx
@@ -7,7 +7,10 @@ import { withStyles } from '@material-ui/core/styles';
 import classNames from 'classnames';
 
 const lineStyles = theme => ({
-  line: styles.line(theme)
+  line: styles.line(theme),
+  disabled: styles.disabled(theme),
+  correct: styles.correct(theme, 'stroke'),
+  incorrect: styles.incorrect(theme, 'stroke')
 });
 export const Line = props => {
   const { className, classes, correctness, disabled, graphProps, from, to, ...rest } = props;

--- a/packages/graphing/src/tools/shared/__tests__/__snapshots__/arrow-head.test.jsx.snap
+++ b/packages/graphing/src/tools/shared/__tests__/__snapshots__/arrow-head.test.jsx.snap
@@ -19,6 +19,7 @@ exports[`ArrowMarker snapshot renders 1`] = `
   viewBox="0 0 10 10"
 >
   <ArrowHead
+    points=""
     size={10}
     transform=""
   />

--- a/packages/graphing/src/tools/shared/arrow-head.jsx
+++ b/packages/graphing/src/tools/shared/arrow-head.jsx
@@ -16,20 +16,22 @@ export const genUid = () => {
   const v = (Math.random() * 1000).toFixed(0);
   return `arrow-${v}`;
 };
-export const ArrowMarker = ({ id, size, className }) => (
-  <marker
-    id={id}
-    viewBox={`0 0 ${size} ${size}`}
-    refX={size / 2}
-    refY={size / 2}
-    markerWidth={size}
-    markerHeight={size}
-    orient="auto-start-reverse"
-    className={className}
-  >
-    <ArrowHead size={size} />
-  </marker>
-);
+export const ArrowMarker = ({ id, size, className }) => {
+  return (
+    <marker
+      id={id}
+      viewBox={`0 0 ${size} ${size}`}
+      refX={size / 2}
+      refY={size / 2}
+      markerWidth={size}
+      markerHeight={size}
+      orient="auto-start-reverse"
+      className={className}
+    >
+      <ArrowHead size={size} />
+    </marker>
+  );
+};
 ArrowMarker.propTypes = {
   id: PropTypes.string,
   size: PropTypes.number,

--- a/packages/graphing/src/tools/shared/arrow-head.jsx
+++ b/packages/graphing/src/tools/shared/arrow-head.jsx
@@ -1,14 +1,16 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-export const ArrowHead = ({ size, transform }) => (
-  <polygon points={`0,0 ${size},${size / 2} 0,${size}`} transform={transform} />
+export const ArrowHead = ({ size, transform, points }) => (
+  <polygon points={points || `0,0 ${size},${size / 2} 0,${size}`} transform={transform} />
 );
 ArrowHead.propTypes = {
+  points: PropTypes.string,
   size: PropTypes.number,
   transform: PropTypes.string
 };
 ArrowHead.defaultProps = {
+  points: '',
   size: 10,
   transform: ''
 };

--- a/packages/graphing/src/tools/shared/line/__tests__/__snapshots__/line-path.test.jsx.snap
+++ b/packages/graphing/src/tools/shared/line/__tests__/__snapshots__/line-path.test.jsx.snap
@@ -5,9 +5,11 @@ exports[`LinePath snapshot renders 1`] = `
   className="className"
   classes={
     Object {
+      "correct": "RawLinePath-correct-5",
       "disabled": "RawLinePath-disabled-4",
       "dragging": "RawLinePath-dragging-3",
       "drawLine": "RawLinePath-drawLine-1",
+      "incorrect": "RawLinePath-incorrect-6",
       "line": "RawLinePath-line-2",
     }
   }

--- a/packages/graphing/src/tools/shared/line/index.jsx
+++ b/packages/graphing/src/tools/shared/line/index.jsx
@@ -114,6 +114,7 @@ export const lineBase = (Comp, opts) => {
       onChange: PropTypes.func,
       onDragStart: PropTypes.func,
       onDragStop: PropTypes.func,
+      onClick: PropTypes.func,
       correctness: PropTypes.string,
       disabled: PropTypes.bool
     };
@@ -138,27 +139,29 @@ export const lineBase = (Comp, opts) => {
     };
 
     render() {
-      const { graphProps, onDragStart, onDragStop, from, to, disabled, correctness } = this.props;
-      const common = { graphProps, onDragStart, onDragStop, disabled, correctness };
+      const {
+        graphProps,
+        onDragStart,
+        onDragStop,
+        from,
+        to,
+        disabled,
+        correctness,
+        onClick
+      } = this.props;
+      const common = { graphProps, onDragStart, onDragStop, disabled, correctness, onClick };
       const angle = to ? trig.toDegrees(trig.angle(from, to)) : 0;
 
       return (
         <g>
           {to && <DraggableComp from={from} to={to} onDrag={this.dragComp} {...common} />}
-          <FromPoint
-            x={from.x}
-            y={from.y}
-            onDrag={this.dragFrom}
-            onClick={this.clickFrom}
-            {...common}
-          />
+          <FromPoint x={from.x} y={from.y} onDrag={this.dragFrom} {...common} />
           {to && (
             <ToPoint
               x={to.x}
               y={to.y}
               angle={angle} //angle + 45}
               onDrag={this.dragTo}
-              onClick={this.clickTo}
               {...common}
             />
           )}

--- a/packages/graphing/src/tools/shared/line/index.jsx
+++ b/packages/graphing/src/tools/shared/line/index.jsx
@@ -4,7 +4,7 @@ import { BasePoint } from '../point';
 import { types, utils, gridDraggable, trig } from '@pie-lib/plot';
 import PropTypes from 'prop-types';
 import debug from 'debug';
-import _ from 'lodash';
+import { disabled, correct, incorrect } from '../styles';
 
 const log = debug('pie-lib:graphing:line-tools');
 
@@ -12,6 +12,10 @@ export const lineTool = (type, Component) => () => ({
   type,
   Component,
   addPoint: (point, mark) => {
+    if (mark && isEqual(mark.root, point)) {
+      return mark;
+    }
+
     if (!mark) {
       return {
         type,
@@ -20,7 +24,7 @@ export const lineTool = (type, Component) => () => ({
       };
     }
 
-    if (_.isEqual(point, mark.from)) {
+    if (isEqual(point, mark.from)) {
       return { ...mark };
     }
 
@@ -63,6 +67,8 @@ export const lineToolComponent = Component => {
       const mark = this.state.mark ? this.state.mark : this.props.mark;
       return (
         <Component
+          disabled={mark.disabled}
+          correctness={mark.correctness}
           from={mark.from}
           to={mark.to}
           graphProps={graphProps}
@@ -107,7 +113,15 @@ export const lineBase = (Comp, opts) => {
       to: types.PointType,
       onChange: PropTypes.func,
       onDragStart: PropTypes.func,
-      onDragStop: PropTypes.func
+      onDragStop: PropTypes.func,
+      correctness: PropTypes.string,
+      disabled: PropTypes.bool
+    };
+
+    onChangePoint = point => {
+      if (!isEqual(point.from, point.to)) {
+        this.props.onChange(point);
+      }
     };
 
     dragComp = ({ from, to }) => {
@@ -116,22 +130,18 @@ export const lineBase = (Comp, opts) => {
     };
 
     dragFrom = from => {
-      const { onChange } = this.props;
-      onChange({ from, to: this.props.to });
+      this.onChangePoint({ from, to: this.props.to });
     };
 
     dragTo = to => {
-      console.log('DRAG TO:', to);
-      const { onChange } = this.props;
-      onChange({ from: this.props.from, to });
+      this.onChangePoint({ from: this.props.from, to });
     };
 
     render() {
-      const { graphProps, onDragStart, onDragStop, from, to } = this.props;
-
-      const common = { graphProps, onDragStart, onDragStop };
-
+      const { graphProps, onDragStart, onDragStop, from, to, disabled, correctness } = this.props;
+      const common = { graphProps, onDragStart, onDragStop, disabled, correctness };
       const angle = to ? trig.toDegrees(trig.angle(from, to)) : 0;
+
       return (
         <g>
           {to && <DraggableComp from={from} to={to} onDrag={this.dragComp} {...common} />}
@@ -173,5 +183,18 @@ export const styles = {
   }),
   arrow: theme => ({
     fill: `var(--point-bg, ${theme.palette.secondary.main})`
+  }),
+  disabledArrow: () => ({
+    ...disabled()
+  }),
+  disabled: () => ({
+    ...disabled('stroke'),
+    strokeWidth: 2
+  }),
+  correct: (theme, key) => ({
+    ...correct(key)
+  }),
+  incorrect: (theme, key) => ({
+    ...incorrect(key)
   })
 };

--- a/packages/graphing/src/tools/shared/line/line-path.jsx
+++ b/packages/graphing/src/tools/shared/line/line-path.jsx
@@ -4,7 +4,7 @@ import { withStyles } from '@material-ui/core/styles';
 import { PointType } from '../types';
 import { types } from '@pie-lib/plot';
 import classNames from 'classnames';
-import { disabled } from '../styles';
+import { disabled, correct, incorrect } from '../styles';
 import * as vx from '@vx/shape';
 
 export class RawLinePath extends React.Component {
@@ -14,6 +14,7 @@ export class RawLinePath extends React.Component {
     data: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.number)),
     graphProps: types.GraphPropsType.isRequired,
     disabled: PropTypes.bool,
+    correctness: PropTypes.string,
     from: PropTypes.shape(PointType).isRequired,
     to: PropTypes.shape(PointType).isRequired,
     isDragging: PropTypes.bool
@@ -26,6 +27,7 @@ export class RawLinePath extends React.Component {
       classes,
       className,
       disabled,
+      correctness,
       from,
       to,
       graphProps,
@@ -38,7 +40,12 @@ export class RawLinePath extends React.Component {
       <React.Fragment>
         <vx.LinePath
           data={data}
-          className={classNames(classes.drawLine, disabled && classes.disabled, className)}
+          className={classNames(
+            classes.drawLine,
+            disabled && classes.disabled,
+            classes[correctness],
+            className
+          )}
           {...rest}
         />
         <vx.LinePath
@@ -47,6 +54,7 @@ export class RawLinePath extends React.Component {
             classes.line,
             isDragging && classes.dragging,
             disabled && classes.disabled,
+            classes[correctness],
             className
           )}
           {...rest}
@@ -78,5 +86,11 @@ export const LinePath = withStyles(theme => ({
   disabled: {
     ...disabled('stroke'),
     strokeWidth: 2
+  },
+  correct: {
+    ...correct('stroke')
+  },
+  incorrect: {
+    ...incorrect('stroke')
   }
 }))(RawLinePath);

--- a/packages/graphing/src/tools/shared/line/with-root-edge.jsx
+++ b/packages/graphing/src/tools/shared/line/with-root-edge.jsx
@@ -49,7 +49,18 @@ export const rootEdgeComponent = RootEdgeComp => {
 
 const withPointsGenerationLinePath = getPoints => {
   const LinePathComponent = props => {
-    const { graphProps, from, to, onClick, onDragStart, onDragStop, onChange, ...rest } = props;
+    const {
+      graphProps,
+      from,
+      to,
+      onClick,
+      onDragStart,
+      onDragStop,
+      onChange,
+      disabled,
+      correctness,
+      ...rest
+    } = props;
 
     const { dataPoints } = getPoints({
       graphProps: props.graphProps,
@@ -58,7 +69,16 @@ const withPointsGenerationLinePath = getPoints => {
     });
     const raw = dataPoints.map(d => [graphProps.scale.x(d.x), graphProps.scale.y(d.y)]);
 
-    const common = { onClick, graphProps, onDragStart, onDragStop, onChange };
+    const common = {
+      onClick,
+      graphProps,
+      onDragStart,
+      onDragStop,
+      onChange,
+      disabled,
+      correctness
+    };
+
     return <LinePath data={raw} from={from} to={to} curve={curveMonotoneX} {...common} {...rest} />;
   };
   LinePathComponent.propTypes = {
@@ -68,7 +88,9 @@ const withPointsGenerationLinePath = getPoints => {
     onClick: PropTypes.func,
     onDragStart: PropTypes.func,
     onDragStop: PropTypes.func,
-    onChange: PropTypes.func
+    onChange: PropTypes.func,
+    disabled: PropTypes.bool,
+    correctness: PropTypes.string
   };
   return LinePathComponent;
 };

--- a/packages/graphing/src/tools/shared/point/arrow.jsx
+++ b/packages/graphing/src/tools/shared/point/arrow.jsx
@@ -32,7 +32,14 @@ export default class Arrow extends React.Component {
     const size = 14;
     const { scale } = graphProps;
 
-    const transform = `translate(${(size / 2) * -1}, ${(size / 2) * -1})`;
+    const scaledX = scale.x(x);
+    const scaledY = scale.y(y);
+    const transform = `translate(${(size / 2) * -1}, ${(size / 2) * -1})
+      rotate(${-1 * angle} ${scaledX + size / 2} ${scaledY + size / 2})`;
+    const points = `${scaledX},${scaledY}
+     ${scaledX + size},${scaledY + size / 2}
+      ${scaledX}, ${scaledY + size}`;
+
     return (
       <g
         className={classNames(
@@ -41,10 +48,9 @@ export default class Arrow extends React.Component {
           classes[correctness],
           className
         )}
-        transform={`translate(${scale.x(x)}, ${scale.y(y)}) rotate(${angle * -1} 0 0)`}
         {...rest}
       >
-        <ArrowHead size={size} transform={transform} />
+        <ArrowHead size={size} transform={transform} points={points} />
       </g>
     );
   }

--- a/packages/graphing/src/tools/sine/index.js
+++ b/packages/graphing/src/tools/sine/index.js
@@ -11,6 +11,10 @@ export const tool = () => ({
   },
   addPoint: (point, mark) => {
     log('add point to sine model: ', point, 'mark: ', mark);
+    if (mark && isEqual(mark.root, point)) {
+      return mark;
+    }
+
     if (!mark) {
       return {
         type: 'sine',

--- a/packages/graphing/src/tools/vector/component.jsx
+++ b/packages/graphing/src/tools/vector/component.jsx
@@ -7,7 +7,10 @@ import classNames from 'classnames';
 import { withStyles } from '@material-ui/core/styles';
 
 const lineStyles = theme => ({
-  line: styles.line(theme)
+  line: styles.line(theme),
+  disabled: styles.disabled(theme),
+  correct: styles.correct(theme, 'stroke'),
+  incorrect: styles.incorrect(theme, 'stroke')
 });
 
 export const Line = props => {


### PR DESCRIPTION
- backgroundMarks were not displaying anymore proper colours for disabled, correct and incorrect. 
- Circle was crashing. 
- Don't allow user to drag pointB over pointA or pointA over pointB for all the elements but polygon.
- for numbers greater than 99, don't let tick labels cut the y axis
- stop app crashing when adding labels
- added a way to determine which tools should be displayed in tool menu. We need this because in pie-element the author can select some background marks, and when he selects the tools that should be displayed to the student, if he deselects a tool that there's already a background mark for, the app will crash (for example, author adds circle as background mark, but when he defines correct answer, he selects not to display circle tool for the student. In that case, in our previously version, the app was crashing, because defining correct response graph was trying to render a background mark with a tool that is not supported). If **displayedTools** is not set, tools will be the default value used.
- Added possibility to plot shapes that include defining points colocated with the defining points of other shapes (https://app.clubhouse.io/keydatasystems/story/2015/graphing-need-to-be-able-to-plot-shapes-that-include-defining-points-colocated-with-the-defining-points-of-other-shapes)