### PR TITLE
fix: render degrees as expected

### DIFF
--- a/packages/editable-html/src/index.jsx
+++ b/packages/editable-html/src/index.jsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 import Editor, { DEFAULT_PLUGINS, ALL_PLUGINS } from './editor';
 import { htmlToValue, valueToHtml } from './serialization';
+import { parseDegrees } from './parse-html';
 import debug from 'debug';
 
 const log = debug('@pie-lib:editable-html');
@@ -59,15 +60,16 @@ export default class EditableHtml extends React.Component {
 
   onChange = (value, done) => {
     const html = valueToHtml(value);
+    const htmlParsed = parseDegrees(html);
 
     log('value as html: ', html);
 
     if (html !== this.props.markup) {
-      this.props.onChange(html);
+      this.props.onChange(htmlParsed);
     }
 
     if (done) {
-      this.props.onDone(html);
+      this.props.onDone(htmlParsed);
     }
   };
 

--- a/packages/editable-html/src/parse-html.js
+++ b/packages/editable-html/src/parse-html.js
@@ -1,0 +1,8 @@
+export const parseDegrees = html =>
+  html
+    // removes \(   use case: 50°
+    .replace(/\\[(]/g, '')
+    // removes \)   use case: 50°+m<1
+    .replace(/\\[)]/g, '')
+    // removes \degree  use case: 50°
+    .replace(/\\degree/g, '&deg;');


### PR DESCRIPTION
The original issue is reported [here](https://app.clubhouse.io/keydatasystems/story/1792/inline-math-degree-symbol-generates-undefined-control-sequence-error-when-rendering).

A very similar issue occurs for `≈` operator, and might occur for others too, but haven't tested for all symbols yet.

Not sure if this is the right approach to fix it, but let me know what you think. 

