### PR TITLE
Fix auto-hide correct answer icon 

### DIFF
--- a/packages/correct-answer-toggle/src/index.jsx
+++ b/packages/correct-answer-toggle/src/index.jsx
@@ -46,41 +46,21 @@ export class CorrectAnswerToggle extends React.Component {
   }
 
   render() {
-    const { classes, className } = this.props;
+    const { classes, className, toggled, hideMessage, showMessage } = this.props;
 
     return (
       <div className={classNames(classes.root, className)}>
         <Expander show={this.state.show} className={classes.expander}>
           <div className={classes.content} onClick={this.onClick.bind(this)}>
             <div className={classes.iconHolder}>
-              <CSSTransition
-                timeout={400}
-                in={this.props.toggled}
-                classNames={classes}
-              >
-                <CorrectResponse
-                  open={true}
-                  key="correct-open"
-                  className={classes.icon}
-                />
+              <CSSTransition timeout={400} in={toggled} exit={!toggled} classNames={classes}>
+                <CorrectResponse open={toggled} key="correct-open" className={classes.icon} />
               </CSSTransition>
-              <CSSTransition
-                timeout={5000}
-                in={!this.props.toggled}
-                classNames={classes}
-              >
-                <CorrectResponse
-                  open={false}
-                  key="correct-closed"
-                  className={classes.icon}
-                />
+              <CSSTransition timeout={5000} in={!toggled} exit={toggled} classNames={classes}>
+                <CorrectResponse open={toggled} key="correct-closed" className={classes.icon} />
               </CSSTransition>
             </div>
-            <div className={classes.label}>
-              {this.props.toggled
-                ? this.props.hideMessage
-                : this.props.showMessage}
-            </div>
+            <div className={classes.label}>{toggled ? hideMessage : showMessage}</div>
           </div>
         </Expander>
       </div>


### PR DESCRIPTION
Issue reported [here](https://app.clubhouse.io/keydatasystems/story/3177/ibx-item-authoring-hide-correct-answer-icon-not-displaying-properly).

Is there any trigger for pushes that auto-indents the code? The lines added seems to be auto-indented. 

Before pushing I had:

```
<CSSTransition 
  timeout={400} 
  in={toggled} 
  exit={!toggled} 
  classNames={classes}
>
```

and after the code changed to

```
<CSSTransition timeout={400} in={toggled} exit={!toggled} classNames={classes}>
```