### PR TITLE
fix(math-toolbar): un-initialized input problem fix in case of no decimal flow

### DIFF
--- a/packages/math-toolbar/src/editor-and-pad.jsx
+++ b/packages/math-toolbar/src/editor-and-pad.jsx
@@ -85,7 +85,7 @@ export class EditorAndPad extends React.Component {
     const { onChange, noDecimal } = this.props;
 
     // if no decimals are allowed and the last change is a decimal dot, discard the change
-    if (noDecimal && (latex.indexOf('.') !== -1 || latex.indexOf(',') !== -1)) {
+    if (noDecimal && (latex.indexOf('.') !== -1 || latex.indexOf(',') !== -1) && this.input) {
       this.input.clear();
       this.input.write(latex.replace(decimalRegex, ''));
       return;


### PR DESCRIPTION
Unfortunately, not something that I can test for - this was breaking 100% in case of noDecimal model for math-inline in initial render. (We need the onChange right after mounting the editor, technical limitation)