### PR TITLE
feat: implement a shuffle/persistence reusable method

### DIFF
--- a/packages/controller-utils/src/__tests__/persistence.test.js
+++ b/packages/controller-utils/src/__tests__/persistence.test.js
@@ -1,0 +1,47 @@
+import { getShuffledChoices } from '../persistence';
+
+describe('persistence', () => {
+  let choices, session, updateSession, key;
+
+  beforeEach(() => {
+    choices = [
+      {
+        value: 1
+      },
+      {
+        value: 2
+      }
+    ];
+    key = 'value';
+  });
+
+  describe('session does not exist', () => {
+    it('returns undefined for empty session', async () => {
+      const result = await getShuffledChoices(choices, session, updateSession, key);
+      expect(result).toEqual(undefined);
+    });
+  });
+
+  describe('session exists', () => {
+    it('returns compact choices if session has shuffledValues', async () => {
+      session = { shuffledValues: [2, 1] };
+      const result = await getShuffledChoices(choices, session, updateSession, key);
+      expect(result).toEqual(expect.arrayContaining(choices));
+    });
+
+    it('returns shuffled choices if updateSession is a function', async () => {
+      session = {};
+      updateSession = jest.fn().mockResolvedValue();
+      const result = await getShuffledChoices(choices, session, updateSession, key);
+      expect(result).toEqual(expect.arrayContaining(choices));
+    });
+
+    it('calls updateSession as expected if updateSession is a function', async () => {
+      session = { id: '1', element: 'pie-element' };
+      await getShuffledChoices(choices, session, updateSession, key);
+      expect(updateSession).toHaveBeenCalledWith('1', 'pie-element', {
+        shuffledValues: expect.arrayContaining([1, 2])
+      });
+    });
+  });
+});

--- a/packages/controller-utils/src/index.js
+++ b/packages/controller-utils/src/index.js
@@ -1,1 +1,2 @@
 export * as partialScoring from './partial-scoring';
+export { getShuffledChoices } from './persistence';

--- a/packages/controller-utils/src/persistence.js
+++ b/packages/controller-utils/src/persistence.js
@@ -1,0 +1,39 @@
+import shuffle from 'lodash/shuffle';
+import compact from 'lodash/compact';
+
+const lg = n => console[n].bind(console);
+const debug = lg('debug');
+const log = lg('log');
+const warn = lg('warn');
+const error = lg('error');
+
+export const getShuffledChoices = async (choices, session, updateSession, key) => {
+  log('updateSession type: ', typeof updateSession);
+  log('session: ', session);
+  if (!session) {
+    warn("unable to save shuffled choices because there's no session.");
+  } else if (session.shuffledValues) {
+    debug('use shuffledValues to sort the choices...', session.shuffledValues);
+
+    return compact(session.shuffledValues.map(v => choices.find(c => c[key] === v)));
+  } else {
+    const shuffledChoices = shuffle(choices);
+
+    if (updateSession && typeof updateSession === 'function') {
+      try {
+        //Note: session.id refers to the id of the element within a session
+        const shuffledValues = shuffledChoices.map(c => c[key]);
+        log('try to save shuffledValues to session...', shuffledValues);
+        console.log('call updateSession... ', session.id, session.element);
+        await updateSession(session.id, session.element, { shuffledValues });
+      } catch (e) {
+        warn('unable to save shuffled order for choices');
+        error(e);
+      }
+    } else {
+      warn('unable to save shuffled choices, shuffle will happen every time.');
+    }
+    //save this shuffle to the session for later retrieval
+    return shuffledChoices;
+  }
+};


### PR DESCRIPTION
Reqs described [here](https://app.clubhouse.io/keydatasystems/story/131/config-ui-support-shuffle-choices).

After approval & merge will the version of `@pie-lib/controller-utils` be `0.1.3`? The latest is `v0.1.2`. I need to know to which version to bump, thinking at the interactions that uses `getShuffledChoices` method.