### PR TITLE
fix: Expand getShuffledChoices function to be used by EBSR as well.

### DIFF
--- a/packages/controller-utils/src/__tests__/persistence.test.js
+++ b/packages/controller-utils/src/__tests__/persistence.test.js
@@ -74,5 +74,40 @@ describe('persistence', () => {
         shuffledValues: expect.arrayContaining([1, 2])
       });
     });
+
+    it('calls updateSession as expected if there is an extraKey', async () => {
+      session = { id: '1', element: 'pie-element' };
+
+      await getShuffledChoices(choices, session, updateSession, key, 'extraKey');
+
+      expect(updateSession).toHaveBeenCalledWith('1', 'pie-element', {
+        shuffledValues: {
+          extraKey: expect.arrayContaining([1, 2])
+        }
+      });
+    });
+
+    it('calls updateSession as expected if there is an extraKey and shuffledValues was already defined', async () => {
+      await getShuffledChoices(
+        choices,
+        {
+          id: '1',
+          element: 'pie-element',
+          shuffledValues: {
+            extraKey: [1, 2]
+          }
+        },
+        updateSession,
+        key,
+        'extraExtraKey'
+      );
+
+      expect(updateSession).toHaveBeenCalledWith('1', 'pie-element', {
+        shuffledValues: {
+          extraKey: expect.arrayContaining([1, 2]),
+          extraExtraKey: expect.arrayContaining([1, 2])
+        }
+      });
+    });
   });
 });


### PR DESCRIPTION
There was an issue with this function when it was used for EBSR:
It was first called for partA, it was adding shuffledValues on the session.
When was called for partB, shuffledValues already existed on the session, so the result that the function was returning was an empty array (filtering choices by sessionValues), meaning that the choices for partB were being set to an empty array.

Note: pie-element/ebsr has to contain the new version of pie-lib/controller-utils after it is merged and released.