### PR TITLE
fix: small text for drag-in-the-blank

### DIFF
--- a/packages/mask-markup/src/choices/choice.jsx
+++ b/packages/mask-markup/src/choices/choice.jsx
@@ -59,7 +59,8 @@ export const BlankContent = withStyles(theme => ({
     alignItems: 'center',
     display: 'inline-flex',
     height: 'initial',
-    minHeight: '32px'
+    minHeight: '32px',
+    fontSize: 'inherit'
   },
   disabled: {}
 }))(BlankContentComp);

--- a/packages/mask-markup/src/components/blank.jsx
+++ b/packages/mask-markup/src/components/blank.jsx
@@ -16,7 +16,8 @@ const useStyles = withStyles(theme => ({
     minWidth: '200px'
   },
   chip: {
-    minWidth: '90px'
+    minWidth: '90px',
+    fontSize: 'inherit'
   },
   correct: {
     border: 'solid 1px green'


### PR DESCRIPTION
In IBX OT, Drag in the Blank items have draggable tokens with text that is too small to comfortably read: prevent using a fontSize of 0.8125rem (material-ui) and override that css property.