### PR TITLE
fix: css

### DIFF
--- a/packages/demo/pages/mask-markup/index.js
+++ b/packages/demo/pages/mask-markup/index.js
@@ -32,9 +32,17 @@ class Demo extends React.Component {
 
     this.state = {
       constructedResponse: {
-        markup,
+        markup: '{{0}} pies de cerca',
         choices: {
-          0: 'blank'
+          0: [
+            {
+              label: '36',
+              value: '0'
+            }
+          ]
+        },
+        value: {
+          0: 'Test'
         }
       },
       inlineDropdown: {

--- a/packages/mask-markup/src/components/__tests__/__snapshots__/correct-input.test.js.snap
+++ b/packages/mask-markup/src/components/__tests__/__snapshots__/correct-input.test.js.snap
@@ -4,10 +4,11 @@ exports[`CorrectInput render renders correctly with correct as false 1`] = `
 <Component
   classes={
     Object {
+      "box": "Component-box-4",
       "correct": "Component-correct-2",
       "incorrect": "Component-incorrect-3",
       "input": "Component-input-1",
-      "notchedOutline": "Component-notchedOutline-4",
+      "notchedOutline": "Component-notchedOutline-5",
     }
   }
   correct={false}
@@ -22,10 +23,11 @@ exports[`CorrectInput render renders correctly with default props 1`] = `
 <Component
   classes={
     Object {
+      "box": "Component-box-4",
       "correct": "Component-correct-2",
       "incorrect": "Component-incorrect-3",
       "input": "Component-input-1",
-      "notchedOutline": "Component-notchedOutline-4",
+      "notchedOutline": "Component-notchedOutline-5",
     }
   }
   correct={false}
@@ -40,10 +42,11 @@ exports[`CorrectInput render renders correctly with disabled prop as true 1`] = 
 <Component
   classes={
     Object {
+      "box": "Component-box-4",
       "correct": "Component-correct-2",
       "incorrect": "Component-incorrect-3",
       "input": "Component-input-1",
-      "notchedOutline": "Component-notchedOutline-4",
+      "notchedOutline": "Component-notchedOutline-5",
     }
   }
   correct={false}

--- a/packages/mask-markup/src/components/correct-input.jsx
+++ b/packages/mask-markup/src/components/correct-input.jsx
@@ -13,6 +13,9 @@ export default withStyles(() => ({
   },
   correct: correctStyle('green'),
   incorrect: correctStyle('red'),
+  box: {
+    fontSize: 'inherit'
+  },
   notchedOutline: {
     borderColor: 'green'
   }


### PR DESCRIPTION
text entry field for Explicit Constructed Response items renders text too small to comfortably read: prevent using a fontSize of 1rem (material-ui) and override that css property.


Could we please make a release for this package after merging?