### PR TITLE
fix: 5590: Force the image to keep its shape

### DIFF
--- a/packages/editable-html/src/plugins/image/__tests__/__snapshots__/component.test.jsx.snap
+++ b/packages/editable-html/src/plugins/image/__tests__/__snapshots__/component.test.jsx.snap
@@ -26,6 +26,7 @@ Array [
       style={
         Object {
           "height": "50px",
+          "objectFit": "contain",
           "width": "50px",
         }
       }

--- a/packages/editable-html/src/plugins/image/component.jsx
+++ b/packages/editable-html/src/plugins/image/component.jsx
@@ -33,7 +33,7 @@ export class Component extends React.Component {
   };
 
   getPercentFromWidth = width => {
-    var floored = width / this.img.naturalWidth * 4;
+    var floored = (width / this.img.naturalWidth) * 4;
     return parseInt(floored.toFixed(0) * 25, 10);
   };
 
@@ -73,14 +73,14 @@ export class Component extends React.Component {
   getSize(data) {
     return {
       width: size(data.get('width')),
-      height: size(data.get('height'))
+      height: size(data.get('height')),
+      objectFit: 'contain'
     };
   }
 
   render() {
     const { node, editor, classes, attributes, onFocus } = this.props;
-    const active =
-      editor.value.isFocused && editor.value.selection.hasEdgeIn(node);
+    const active = editor.value.isFocused && editor.value.selection.hasEdgeIn(node);
     const src = node.data.get('src');
     const percent = node.data.get('percent');
     const loaded = node.data.get('loaded') !== false;
@@ -99,26 +99,19 @@ export class Component extends React.Component {
       deleteStatus === 'pending' && classes.pendingDelete
     );
 
-    const progressClasses = classNames(
-      classes.progress,
-      loaded && classes.hideProgress
-    );
+    const progressClasses = classNames(classes.progress, loaded && classes.hideProgress);
 
     return [
-      <span key={'sp1'}>
-        &nbsp;
-      </span>,
+      <span key={'sp1'}>&nbsp;</span>,
       <div key={'comp'} onFocus={onFocus} className={className}>
         <LinearProgress
           mode="determinate"
           value={percent > 0 ? percent : 0}
           className={progressClasses}
         />
-        <img src={src} {...attributes} ref={r => (this.img = r)} style={size}/>
+        <img src={src} {...attributes} ref={r => (this.img = r)} style={size} />
       </div>,
-      <span key={'sp2'}>
-        &nbsp;
-      </span>
+      <span key={'sp2'}>&nbsp;</span>
     ];
   }
 }

--- a/packages/editable-html/src/plugins/image/index.jsx
+++ b/packages/editable-html/src/plugins/image/index.jsx
@@ -25,9 +25,7 @@ export default function ImagePlugin(opts) {
 
       const change = value.change().insertInline(inline);
       onChange(change);
-      opts.insertImageRequested(
-        getValue => new InsertImageHandler(inline, getValue, onChange)
-      );
+      opts.insertImageRequested(getValue => new InsertImageHandler(inline, getValue, onChange));
     },
     supports: node => node.object === 'inline' && node.type === 'image',
     customToolbar: (node, value, onToolbarDone) => {
@@ -43,9 +41,7 @@ export default function ImagePlugin(opts) {
         onToolbarDone(change, false);
       };
 
-      const Tb = () => (
-        <ImageToolbar percent={percent || 100} onChange={onChange} />
-      );
+      const Tb = () => <ImageToolbar percent={percent || 100} onChange={onChange} />;
       return Tb;
     },
     showDone: true
@@ -57,9 +53,7 @@ export default function ImagePlugin(opts) {
     deleteNode: (e, node, value, onChange) => {
       e.preventDefault();
       if (opts.onDelete) {
-        const update = node.data.merge(
-          Data.create({ deleteStatus: 'pending' })
-        );
+        const update = node.data.merge(Data.create({ deleteStatus: 'pending' }));
 
         let change = value.change().setNodeByKey(node.key, { data: update });
 
@@ -71,10 +65,7 @@ export default function ImagePlugin(opts) {
             log('[error]: ', err);
             change = v
               .change()
-              .setNodeByKey(
-                node.key,
-                node.data.merge(Data.create({ deleteStatus: 'failed' }))
-              );
+              .setNodeByKey(node.key, node.data.merge(Data.create({ deleteStatus: 'failed' })));
           }
           onChange(change);
         });
@@ -119,11 +110,7 @@ export default function ImagePlugin(opts) {
         }
 
         if (d.type === 'image') {
-          if (
-            index > 0 &&
-            textNodeMap[index - 1] &&
-            textNodeMap[index - 1].text === ''
-          ) {
+          if (index > 0 && textNodeMap[index - 1] && textNodeMap[index - 1].text === '') {
             updateNodesArray.push(textNodeMap[index - 1]);
           }
         }
@@ -180,6 +167,8 @@ export const serialization = {
     if (height) {
       style.height = `${height}px`;
     }
+
+    style.objectFit = 'contain';
 
     const props = {
       src,


### PR DESCRIPTION
IBX rendering of images in MC answer choices stretches them vertically (or squeezes them horizontally), causing distortion that invalidates some items.