### PR TITLE
fix: 6287: Setting equation editor as a string (eg: '6') works as well

### DIFF
--- a/packages/math-input/src/keys/__tests__/utils.test.js
+++ b/packages/math-input/src/keys/__tests__/utils.test.js
@@ -21,7 +21,7 @@ describe('utils', () => {
   });
 
   describe('keysForGrade', () => {
-    it.only.each`
+    it.each`
       key                   | expected
       ${'1'}                | ${undefined}
       ${'2'}                | ${undefined}

--- a/packages/math-input/src/keys/__tests__/utils.test.js
+++ b/packages/math-input/src/keys/__tests__/utils.test.js
@@ -21,59 +21,34 @@ describe('utils', () => {
   });
 
   describe('keysForGrade', () => {
-    const assertKeysForGrade = (key, expected) => {
-      it(`if n = ${key}`, () => {
-        const result = keysForGrade(key);
+    it.only.each`
+      key                   | expected
+      ${'1'}                | ${undefined}
+      ${'2'}                | ${undefined}
+      ${'3'}                | ${gradeSets[0].set}
+      ${'4'}                | ${gradeSets[0].set}
+      ${'5'}                | ${gradeSets[0].set}
+      ${'6'}                | ${gradeSets[1].set}
+      ${'7'}                | ${gradeSets[1].set}
+      ${'8'}                | ${gradeSets[2].set}
+      ${'9'}                | ${gradeSets[2].set}
+      ${'HS'}               | ${gradeSets[2].set}
+      ${'geometry'}         | ${gradeSets[3].set}
+      ${'everything'}       | ${gradeSets[4].set}
+      ${'advanced-algebra'} | ${gradeSets[5].set}
+      ${'statistics'}       | ${gradeSets[6].set}
+      ${'something else'}   | ${undefined}
+      ${undefined}          | ${[]}
+      ${null}               | ${[]}
+      ${0}                  | ${[]}
+      ${'0'}                | ${[]}
+    `('$key => $expected', ({ key, expected }) => {
+      expect(keysForGrade(key)).toEqual(expected);
 
-        expect(result).toEqual(expected);
-      });
-    };
-
-    assertKeysForGrade(1, undefined);
-    assertKeysForGrade('1', undefined);
-
-    assertKeysForGrade(2, undefined);
-    assertKeysForGrade('2', undefined);
-
-    assertKeysForGrade(3, gradeSets[0].set);
-    assertKeysForGrade('3', gradeSets[0].set);
-
-    assertKeysForGrade(4, gradeSets[0].set);
-    assertKeysForGrade('4', gradeSets[0].set);
-
-    assertKeysForGrade(5, gradeSets[0].set);
-    assertKeysForGrade('5', gradeSets[0].set);
-
-    assertKeysForGrade(6, gradeSets[1].set);
-    assertKeysForGrade('6', gradeSets[1].set);
-
-    assertKeysForGrade(7, gradeSets[1].set);
-    assertKeysForGrade('7', gradeSets[1].set);
-
-    assertKeysForGrade(8, gradeSets[2].set);
-    assertKeysForGrade('8', gradeSets[2].set);
-
-    assertKeysForGrade(9, gradeSets[2].set);
-    assertKeysForGrade('9', gradeSets[2].set);
-
-    assertKeysForGrade('HS', gradeSets[2].set);
-
-    assertKeysForGrade('geometry', gradeSets[3].set);
-
-    assertKeysForGrade('everything', gradeSets[4].set);
-
-    assertKeysForGrade('advanced-algebra', gradeSets[5].set);
-
-    assertKeysForGrade('statistics', gradeSets[6].set);
-
-    // exceptions
-    assertKeysForGrade('something else', undefined);
-
-    assertKeysForGrade(undefined, []);
-
-    assertKeysForGrade(null, []);
-
-    assertKeysForGrade(0, []);
-    assertKeysForGrade('0', undefined);
+      const n = parseInt(key, 10);
+      if (!isNaN(n)) {
+        expect(keysForGrade(n)).toEqual(expected);
+      }
+    });
   });
 });

--- a/packages/math-input/src/keys/__tests__/utils.test.js
+++ b/packages/math-input/src/keys/__tests__/utils.test.js
@@ -1,6 +1,7 @@
 import { extendKeySet } from '../utils';
-import { keysForGrade } from '../grades';
+import { keysForGrade, gradeSets } from '../grades';
 import * as comparison from '../../keys/comparison';
+
 describe('utils', () => {
   const base = [[comparison.lessThan]];
   describe('extendKeySet', () => {
@@ -17,5 +18,62 @@ describe('utils', () => {
       const resultTwo = extendKeySet(base, []);
       expect(result).toEqual(resultTwo);
     });
+  });
+
+  describe('keysForGrade', () => {
+    const assertKeysForGrade = (key, expected) => {
+      it(`if n = ${key}`, () => {
+        const result = keysForGrade(key);
+
+        expect(result).toEqual(expected);
+      });
+    };
+
+    assertKeysForGrade(1, undefined);
+    assertKeysForGrade('1', undefined);
+
+    assertKeysForGrade(2, undefined);
+    assertKeysForGrade('2', undefined);
+
+    assertKeysForGrade(3, gradeSets[0].set);
+    assertKeysForGrade('3', gradeSets[0].set);
+
+    assertKeysForGrade(4, gradeSets[0].set);
+    assertKeysForGrade('4', gradeSets[0].set);
+
+    assertKeysForGrade(5, gradeSets[0].set);
+    assertKeysForGrade('5', gradeSets[0].set);
+
+    assertKeysForGrade(6, gradeSets[1].set);
+    assertKeysForGrade('6', gradeSets[1].set);
+
+    assertKeysForGrade(7, gradeSets[1].set);
+    assertKeysForGrade('7', gradeSets[1].set);
+
+    assertKeysForGrade(8, gradeSets[2].set);
+    assertKeysForGrade('8', gradeSets[2].set);
+
+    assertKeysForGrade(9, gradeSets[2].set);
+    assertKeysForGrade('9', gradeSets[2].set);
+
+    assertKeysForGrade('HS', gradeSets[2].set);
+
+    assertKeysForGrade('geometry', gradeSets[3].set);
+
+    assertKeysForGrade('everything', gradeSets[4].set);
+
+    assertKeysForGrade('advanced-algebra', gradeSets[5].set);
+
+    assertKeysForGrade('statistics', gradeSets[6].set);
+
+    // exceptions
+    assertKeysForGrade('something else', undefined);
+
+    assertKeysForGrade(undefined, []);
+
+    assertKeysForGrade(null, []);
+
+    assertKeysForGrade(0, []);
+    assertKeysForGrade('0', undefined);
   });
 });

--- a/packages/math-input/src/keys/grades.js
+++ b/packages/math-input/src/keys/grades.js
@@ -52,7 +52,7 @@ const gradeSets = [
     ]
   },
   {
-    predicate: n => n === 6 || n === 7,
+    predicate: n => n >= 6 && n <= 7,
     set: [
       [vars.x, vars.y, exponent.squared, exponent.squareRoot, operators.circleDot],
       [fractions.xOverBlank, fractions.xBlankBlank, exponent.xToPowerOfN, exponent.nthRoot],

--- a/packages/math-input/src/keys/grades.js
+++ b/packages/math-input/src/keys/grades.js
@@ -173,6 +173,8 @@ export const gradeSets = [
 ];
 
 export const keysForGrade = n => {
+  const number = parseInt(n, 10);
+  n = isNaN(number) ? n : number;
   if (!n) {
     return [];
   }

--- a/packages/math-input/src/keys/grades.js
+++ b/packages/math-input/src/keys/grades.js
@@ -42,7 +42,7 @@ const statisticsSet = (() => {
   return out;
 })();
 
-const gradeSets = [
+export const gradeSets = [
   {
     predicate: n => n >= 3 && n <= 5,
     set: [
@@ -184,6 +184,7 @@ export const keysForGrade = n => {
       return gs.predicate(n);
     }
   });
+
   if (match) {
     return match.set || [];
   }


### PR DESCRIPTION
(In OT, a math editor for an Equation Response item is missing a critical button as well as many other expected buttons)