### PR TITLE
fix: ch5349, ch5736 & ch4155:

### DIFF
--- a/packages/graphing/src/__tests__/utils.test.js
+++ b/packages/graphing/src/__tests__/utils.test.js
@@ -62,5 +62,40 @@ describe('utils', () => {
     assertGetTickValues({ min: 0, max: 3, step: 0.5 }, [0, 0.5, 1, 1.5, 2, 2.5, 3]);
     assertGetTickValues({ min: -0.2, max: 2, step: 0.6 }, [0, 0.6, 1.2, 1.8]);
     assertGetTickValues({ min: -3.4, max: 6.2, step: 1.2 }, [0, -1.2, -2.4, 1.2, 2.4, 3.6, 4.8, 6]);
+
+    assertGetTickValues({ min: 0.6, max: 4.8, step: 0.3 }, [
+      0.6,
+      0.9,
+      1.2,
+      1.5,
+      1.8,
+      2.1,
+      2.4,
+      2.7,
+      3.0,
+      3.3,
+      3.6,
+      3.9,
+      4.2,
+      4.5,
+      4.8
+    ]);
+    assertGetTickValues({ min: 0.5, max: 4.9, step: 0.3 }, [
+      0.6,
+      0.9,
+      1.2,
+      1.5,
+      1.8,
+      2.1,
+      2.4,
+      2.7,
+      3.0,
+      3.3,
+      3.6,
+      3.9,
+      4.2,
+      4.5,
+      4.8
+    ]);
   });
 });

--- a/packages/graphing/src/axis/__tests__/__snapshots__/axes.test.jsx.snap
+++ b/packages/graphing/src/axis/__tests__/__snapshots__/axes.test.jsx.snap
@@ -9,7 +9,6 @@ exports[`RawXAxis snapshot renders 1`] = `
     tickLabelProps={[Function]}
     tickValues={
       Array [
-        "0",
         0,
       ]
     }

--- a/packages/graphing/src/utils.js
+++ b/packages/graphing/src/utils.js
@@ -24,7 +24,12 @@ export const getTickValues = prop => {
     tickVal = Math.round((tickVal + prop.step) * 100) / 100;
   }
 
-  return tickValues;
+  // return only ticks that are inside the min-max interval
+  if (tickValues) {
+    return tickValues.filter(tV => tV >= prop.min && tV <= prop.max);
+  }
+
+  return [];
 };
 
 export const polygonToArea = points => {


### PR DESCRIPTION
- 5349: For Graphing items, move the origin label
- 5736: In Graphing, the horizontal alignment of multi-digit numeric labels for the x-axis is off
- 4155: Graphing item that wasn't supposed to have an x-axis or a y-axis still has them.