### PR TITLE
fix: PD-19: When authoring Select Text content, extra spaces are inserted before periods.

### DIFF
--- a/packages/demo/pages/text-select.jsx
+++ b/packages/demo/pages/text-select.jsx
@@ -4,17 +4,27 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { withStyles } from '@material-ui/core/styles';
 import { Header, Body } from '../src/formatting';
-import clone from 'lodash/clone';
 import classNames from 'classnames';
 import green from '@material-ui/core/colors/green';
 import orange from '@material-ui/core/colors/orange';
 import compact from 'lodash/compact';
 
 const text = () => [
+  'This is sentence a.',
+  'This is sentence b.',
   'Rachel cut out 8 stars in 6 minutes.',
   'Lovelle cut out 6 stars in 4 minutes.',
   'Rachel cut out 4 more stars than Lovelle.',
-  'Lovelle and Rachel cut the same number of stars in 6 minutes.'
+  'Lovelle and Rachel cut the same number of stars in 6 minutes.',
+  'I am Mrs. Pink.',
+  'This is sentence 1.',
+  'This is sentence 2.',
+  'This is sentence 3.',
+  'This is sentence 4.',
+  'Sentence 1.',
+  'Sentence 2.',
+  'Sentence 3.',
+  'Dr. A. says he will call in 2.'
 ];
 
 const raw = text().join(' ');

--- a/packages/text-select/src/tokenizer/__tests__/builder.test.js
+++ b/packages/text-select/src/tokenizer/__tests__/builder.test.js
@@ -169,12 +169,30 @@ describe('builder', () => {
       expect(out[0]).toEqual({ text: 'This is foo.', start: 0, end: 12 });
       expect(out[1]).toEqual({ text: 'This is bar.', start: 13, end: 25 });
     });
+
     it('works', () => {
       const text =
         'On Jan. 20, former Sen. Barack Obama became the 44th President of the USA. Millions attended the Inauguration.';
 
       const out = sentences(text);
       expect(out.length).toEqual(2);
+    });
+
+    it('works for sentences ending in one-character-words', () => {
+      const text =
+        'This is Sentence 1. This is Sentence 2. This is Sentence 3. This is Sentence 4. Dr. A. said he\'ll call in 5.' ;
+
+      const out = sentences(text);
+
+      expect(out.length).toEqual(5);
+
+      expect(out).toEqual([
+        { text: 'This is Sentence 1.', start: 0, end: 19 },
+        { text: 'This is Sentence 2.', start: 20, end: 39 },
+        { text: 'This is Sentence 3.', start: 40, end: 59 },
+        { text: 'This is Sentence 4.', start: 60, end: 79 },
+        { text: 'Dr. A. said he\'ll call in 5.', start: 80, end: 108 },
+      ])
     });
   });
 
@@ -193,6 +211,7 @@ describe('builder', () => {
         end: 57
       });
     });
+
     it('works', () => {
       const text =
         'On Jan. 20, former Sen. Barack Obama became the 44th President of the USA. Millions attended the Inauguration.' +


### PR DESCRIPTION
English.parse does not work properly with sentences that end with one-character-word.

Fix: make sentence parser to work with sentences that end with one-character-word.

After a version that has the fix is released, pie-element/select-text has to be updated properly to fix PD-19.