### PR TITLE
fix: PD-155: In IBX and Sandbox math editors, the pink highlighting used on certain buttons is missing

### DIFF
--- a/packages/math-input/src/keypad/index.jsx
+++ b/packages/math-input/src/keypad/index.jsx
@@ -24,7 +24,7 @@ const LatexButton = withStyles(theme => ({
   latexButton: {
     pointerEvents: 'none',
     '& .mq-empty': {
-      backgroundColor: fade(theme.palette.secondary.main, 0.4)
+      backgroundColor: `${fade(theme.palette.secondary.main, 0.4)} !important`
     },
     '& .mq-overarrow': {
       width: '30px'


### PR DESCRIPTION
The "pink" background-color set on .mq-empty is overwritten by mathquill.css with "transparent". Added "important" to prevent this.