### PR TITLE
fix: PD-158: fixed scaled items

### DIFF
--- a/packages/math-input/src/keypad/index.jsx
+++ b/packages/math-input/src/keypad/index.jsx
@@ -23,6 +23,12 @@ const LatexButton = withStyles(theme => ({
   },
   latexButton: {
     pointerEvents: 'none',
+    '& .mq-scaled.mq-sqrt-prefix': {
+      transform: 'scale(1, 0.9) !important'
+    },
+    '& .mq-sup-only .mq-sup': {
+      marginBottom: '0.9px !important'
+    },
     '& .mq-empty': {
       backgroundColor: fade(theme.palette.secondary.main, 0.4)
     },


### PR DESCRIPTION
In Item Preview specifically, in IBX only, the math editor radical button and the "squared" button are not correctly labeled