### PR TITLE
fix(inline-dropdown): render item as html - PD-887

### DIFF
--- a/packages/mask-markup/src/components/dropdown.jsx
+++ b/packages/mask-markup/src/components/dropdown.jsx
@@ -6,6 +6,10 @@ import CorrectInput from './correct-input';
 import { withStyles } from '@material-ui/core/styles';
 import { color } from '@pie-lib/render-ui';
 
+//Used these below to replace \\embed{newLine} with \\newline from prompt which will get parsed in MathJax
+const NEWLINE_BLOCK_REGEX = /\\embed\{newLine\}\[\]/g;
+const NEWLINE_LATEX = '\\newline ';
+
 class Dropdown extends React.Component {
   static propTypes = {
     id: PropTypes.string,
@@ -80,12 +84,14 @@ class Dropdown extends React.Component {
             key={`${c.label}-${index}`}
             value={c.value}
           >
-            <span>
-              {c.label}
-              {showCheckmark && (
-                <span dangerouslySetInnerHTML={{ __html: c.value === value ? ' &check;' : '' }} />
-              )}
-            </span>
+            <span
+              dangerouslySetInnerHTML={{
+                __html: c.label.replace(NEWLINE_BLOCK_REGEX, NEWLINE_LATEX)
+              }}
+            />
+            {showCheckmark && (
+              <span dangerouslySetInnerHTML={{ __html: c.value === value ? ' &check;' : '' }} />
+            )}
           </MenuItem>
         ))}
       </Select>

--- a/packages/mask-markup/src/components/dropdown.jsx
+++ b/packages/mask-markup/src/components/dropdown.jsx
@@ -6,10 +6,6 @@ import CorrectInput from './correct-input';
 import { withStyles } from '@material-ui/core/styles';
 import { color } from '@pie-lib/render-ui';
 
-//Used these below to replace \\embed{newLine} with \\newline from prompt which will get parsed in MathJax
-const NEWLINE_BLOCK_REGEX = /\\embed\{newLine\}\[\]/g;
-const NEWLINE_LATEX = '\\newline ';
-
 class Dropdown extends React.Component {
   static propTypes = {
     id: PropTypes.string,
@@ -86,7 +82,7 @@ class Dropdown extends React.Component {
           >
             <span
               dangerouslySetInnerHTML={{
-                __html: c.label.replace(NEWLINE_BLOCK_REGEX, NEWLINE_LATEX)
+                __html: c.label
               }}
             />
             {showCheckmark && (


### PR DESCRIPTION
For the inline-dropdown element, render new choices as html in the player side, not as string.
https://illuminate.atlassian.net/secure/RapidBoard.jspa?rapidView=439&projectKey=PD&modal=detail&selectedIssue=PD-887&assignee=601120f0c8c36c0069681445