### PR TITLE
fix(config-ui): fix choices map null check - PD-879

### DIFF
--- a/packages/config-ui/src/settings/panel.jsx
+++ b/packages/config-ui/src/settings/panel.jsx
@@ -73,7 +73,7 @@ const Dropdown = withStyles({
     borderRadius: '4px',
     padding: '0 8px'
   }
-})(({ classes, label, value, onChange, choices }) => {
+})(({ classes, label, value, onChange, choices = [] }) => {
   return (
     <div>
       {label && <p className={classes.label}>{label}</p>}


### PR DESCRIPTION
Some interactions were simply reliant on the choices array being present. This way at least it won't break the interaction down entirely if it's missing. `3eb3a4ac-eccb-11ea-a4dd-b27091dc957b` breaks it entirely.