### PR TITLE
fix: In some situations, math editors will not accept keyboard entry  PD-655.

### DIFF
--- a/packages/math-input/src/mq/input.jsx
+++ b/packages/math-input/src/mq/input.jsx
@@ -72,6 +72,11 @@ export class Input extends React.Component {
   focus() {
     log('focus mathfield...');
     this.mathField.focus();
+
+    setTimeout(() => {
+      this.mathField.blur();
+      this.mathField.focus();
+    }, 0);
   }
 
   command(v) {


### PR DESCRIPTION
https://illuminate.atlassian.net/browse/PD-655

I don't think this is the best solution, but couldn't find a better one.

The issue is that the field gets to be focused before it has the proper handlers set.
(I've tried to find a callback/a way to figure out when handlers are ready without success).

The 0 timeout and combination of steps does the trick.
Notes: having only focus inside the timeout (without the focus - blur - focus steps) does not work.
