### PR TITLE
fix(text-select): fix token display style - PD-643

### DIFF
--- a/packages/text-select/src/token-select/token.jsx
+++ b/packages/text-select/src/token-select/token.jsx
@@ -116,7 +116,7 @@ export default withStyles(theme => {
       lineHeight: 2,
       boxSizing: 'border-box',
       marginTop: theme.spacing.unit / 2,
-      display: 'inline-block',
+      display: 'inline',
       padding: theme.spacing.unit
     },
 


### PR DESCRIPTION
This fixes a lot more problems than it introduces. We'll need to treat line-breaks a little differently or style them separately. Having `inline-block` on tokens breaks too many interactions and is simply not worth it. It severely disrupts what the interaction should be like (seamlessly insert tokens into text without breaking layout or text flow).