### PR TITLE
fix(mask-markup): fix dragging issue by overwriting material ui chip height

### DIFF
--- a/packages/mask-markup/src/components/__tests__/__snapshots__/blank.test.js.snap
+++ b/packages/mask-markup/src/components/__tests__/__snapshots__/blank.test.js.snap
@@ -9,6 +9,7 @@ exports[`Blank render renders correctly with default props 1`] = `
        
     </span>
   }
+  style={Object {}}
 />
 `;
 
@@ -21,6 +22,7 @@ exports[`Blank render renders correctly with disabled prop as true 1`] = `
        
     </span>
   }
+  style={Object {}}
   variant="outlined"
 />
 `;
@@ -34,6 +36,7 @@ exports[`Blank render renders correctly with draggedItem 1`] = `
        
     </span>
   }
+  style={Object {}}
 />
 `;
 
@@ -46,5 +49,6 @@ exports[`Blank render renders correctly with draggedItem and isOver 1`] = `
        
     </span>
   }
+  style={Object {}}
 />
 `;

--- a/packages/mask-markup/src/components/blank.jsx
+++ b/packages/mask-markup/src/components/blank.jsx
@@ -20,7 +20,6 @@ const useStyles = withStyles(() => ({
     minWidth: '90px',
     fontSize: 'inherit',
     minHeight: '32px',
-    height: 'auto',
     maxWidth: '374px'
   },
   chipLabel: {
@@ -47,8 +46,31 @@ export class BlankContent extends React.Component {
     onChange: PropTypes.func
   };
 
-  componentDidUpdate() {
+  constructor() {
+    super();
+    this.state = {
+      height: 0
+    };
+  }
+
+  componentDidUpdate(prevProps) {
     renderMath(this.rootRef);
+    const { choice: currentChoice } = this.props;
+    const { choice: prevChoice } = prevProps;
+
+    if (JSON.stringify(currentChoice) !== JSON.stringify(prevChoice)) {
+      if (!currentChoice) {
+        this.setState({
+          height: 0
+        });
+        return;
+      }
+      setTimeout(() => {
+        this.setState({
+          height: this.spanRef.offsetHeight
+        });
+      }, 300);
+    }
   }
 
   render() {
@@ -67,6 +89,8 @@ export class BlankContent extends React.Component {
             className={classes.chipLabel}
             ref={ref => {
               if (ref) {
+                //eslint-disable-next-line
+                this.spanRef = ReactDOM.findDOMNode(ref);
                 ref.innerHTML = label || '';
               }
             }}
@@ -79,6 +103,9 @@ export class BlankContent extends React.Component {
           [classes.incorrect]: correct !== undefined && !correct
         })}
         variant={disabled ? 'outlined' : undefined}
+        style={{
+          ...(this.state.height ? { height: this.state.height } : {})
+        }}
       />
     );
   }


### PR DESCRIPTION
It's a hacky fix, but I've already spend some time on it. Setting `height: auto` will make some of the chip items to not be draggable anymore.

[PD-1034](https://illuminate.atlassian.net/browse/PD-1034)