### PR TITLE
Fix for Charting and Graphing, in IBX and OT, labels are too small - PD-533

### DIFF
--- a/packages/charting/src/axes.jsx
+++ b/packages/charting/src/axes.jsx
@@ -206,7 +206,7 @@ export class RawChartAxes extends React.Component {
 const ChartAxes = withStyles(theme => ({
   axisLabel: {
     fontFamily: theme.typography.body1.fontFamily,
-    fontSize: theme.typography.body1.fontSize,
+    fontSize: theme.typography.fontSize,
     fill: color.secondary()
   },
   axis: {
@@ -224,7 +224,7 @@ const ChartAxes = withStyles(theme => ({
     },
     fill: color.primaryDark(),
     fontFamily: theme.typography.body1.fontFamily,
-    fontSize: theme.typography.overline.fontSize,
+    fontSize: theme.typography.fontSize,
     textAnchor: 'middle'
   },
   dottedLine: {

--- a/packages/charting/src/tool-menu.jsx
+++ b/packages/charting/src/tool-menu.jsx
@@ -7,14 +7,15 @@ import { withStyles } from '@material-ui/core/styles';
 import cn from 'classnames';
 import Button from '@material-ui/core/Button';
 
-const buttonStyles = () => ({
+const buttonStyles = theme => ({
   root: {
     backgroundColor: color.background(),
     color: color.text(),
     border: `1px solid ${color.secondary()}`,
     '&:hover': {
       backgroundColor: color.secondaryLight()
-    }
+    },
+    fontSize: theme.typography.fontSize
   },
   selected: {
     backgroundColor: color.background(),

--- a/packages/graphing/src/axis/axes.jsx
+++ b/packages/graphing/src/axis/axes.jsx
@@ -31,6 +31,9 @@ const axisStyles = theme => ({
       stroke: color.primary()
     }
   },
+  labelFontSize: {
+    fontSize: theme.typography.fontSize
+  },
   axisLabelHolder: {
     padding: 0,
     margin: 0,
@@ -38,7 +41,8 @@ const axisStyles = theme => ({
     '* > *': {
       margin: 0,
       padding: 0
-    }
+    },
+    fontSize: theme.typography.fontSize
   }
 });
 
@@ -155,7 +159,10 @@ export class RawXAxis extends React.Component {
             width={necessaryWidth}
             height={20 * necessaryRows}
           >
-            <div dangerouslySetInnerHTML={{ __html: domain.axisLabel }} />
+            <div
+              dangerouslySetInnerHTML={{ __html: domain.axisLabel }}
+              className={classes.labelFontSize}
+            />
           </foreignObject>
         )}
       </React.Fragment>

--- a/packages/graphing/src/graph-with-controls.jsx
+++ b/packages/graphing/src/graph-with-controls.jsx
@@ -130,7 +130,7 @@ const styles = theme => ({
     borderLeft: `solid 1px ${color.primaryDark()}`,
     borderRight: `solid 1px ${color.primaryDark()}`,
     '& button': {
-      fontSize: 'inherit'
+      fontSize: theme.typography.fontSize
     }
   }
 });

--- a/packages/graphing/src/labels.jsx
+++ b/packages/graphing/src/labels.jsx
@@ -34,6 +34,8 @@ const getY = (side, height) => {
       return -height;
     case 'top':
       return -height + 10;
+    case 'right':
+      return -height + 10;
     default:
       return 0;
   }
@@ -43,11 +45,12 @@ class RawLabel extends React.Component {
   static propTypes = {
     text: PropTypes.string,
     side: PropTypes.string,
+    classes: PropTypes.object,
     graphProps: types.GraphPropsType.isRequired
   };
 
   render() {
-    const { text, side, graphProps } = this.props;
+    const { text, side, graphProps, classes } = this.props;
 
     const { size } = graphProps;
 
@@ -65,15 +68,19 @@ class RawLabel extends React.Component {
         transform={transform}
         textAnchor="middle"
       >
-        <div style={{ textAlign: 'center' }} dangerouslySetInnerHTML={{ __html: text }} />
+        <div dangerouslySetInnerHTML={{ __html: text }} className={classes.axisLabel} />
       </foreignObject>
     );
   }
 }
 
-const Label = withStyles(() => ({
+const Label = withStyles(theme => ({
   label: {
     fill: color.secondary()
+  },
+  axisLabel: {
+    fontSize: theme.typography.fontSize,
+    textAlign: 'center'
   }
 }))(RawLabel);
 
@@ -93,7 +100,6 @@ export class Labels extends React.Component {
   };
 
   static defaultProps = {};
-
   render() {
     const { value, graphProps } = this.props;
     return (

--- a/packages/graphing/src/toggle-bar.jsx
+++ b/packages/graphing/src/toggle-bar.jsx
@@ -99,6 +99,7 @@ export class ToggleBar extends React.Component {
 const styles = theme => ({
   button: {
     marginRight: theme.spacing.unit / 2,
+    marginBottom: theme.spacing.unit / 2,
     color: color.text(),
     backgroundColor: color.background()
   }

--- a/packages/graphing/src/undo-redo.jsx
+++ b/packages/graphing/src/undo-redo.jsx
@@ -37,7 +37,8 @@ const styles = theme => ({
     color: color.text(),
     backgroundColor: color.background(),
     '&:not(:last-of-type)': {
-      marginRight: theme.spacing.unit / 2
+      marginRight: theme.spacing.unit / 2,
+      marginBottom: theme.spacing.unit / 2
     },
     '&:hover': {
       backgroundColor: color.primary()

--- a/packages/plot/src/root.jsx
+++ b/packages/plot/src/root.jsx
@@ -12,7 +12,8 @@ export const GraphTitle = withStyles(theme => ({
   title: {
     color: color.text(),
     textAlign: 'center',
-    paddingTop: theme.spacing.unit * 2
+    paddingTop: theme.spacing.unit * 2,
+    fontSize: theme.typography.fontSize + 6
   }
 }))(({ value, classes }) => (
   <Typography className={classes.title} variant="h5" color="primary">


### PR DESCRIPTION
Fix for Charting and Graphing, in IBX and OT, x- and y-axis labels and y-axis numeric labels are too small 


https://illuminate.atlassian.net/browse/PD-533