### PR TITLE
fix(mask-markup): Fixed labels overlapping

### DIFF
--- a/packages/mask-markup/src/components/blank.jsx
+++ b/packages/mask-markup/src/components/blank.jsx
@@ -27,7 +27,8 @@ const useStyles = withStyles(() => ({
     whiteSpace: 'pre-wrap'
   },
   hidden: {
-    color: 'transparent'
+    color: 'transparent',
+    opacity: 0
   },
   dragged: {
     position: 'absolute',


### PR DESCRIPTION
In DITB, when a label is dragged on another label, the old label should be hidden, but when we have images, this is not happening. 