### PR TITLE
fix(editor): made sure that if the editor loses focus, the onBlur function is called only if the focus is still not inside the dom element [PD-1126]

### DIFF
--- a/packages/editable-html/src/editor.jsx
+++ b/packages/editable-html/src/editor.jsx
@@ -303,6 +303,26 @@ export class Editor extends React.Component {
     });
   };
 
+  handleDomBlur = e => {
+    const editorDOM = document.querySelector(`[data-key="${this.state.value.document.key}"]`);
+
+    setTimeout(() => {
+      if (!this.wrapperRef) {
+        return;
+      }
+
+      const editorElement = document.activeElement.closest('[class*=editorHolder]');
+      const toolbarElement = document.activeElement.closest('[class*=Toolbar-focused]');
+      const isInCurrentComponent =
+        this.wrapperRef.contains(editorElement) || this.wrapperRef.contains(toolbarElement);
+
+      if (!isInCurrentComponent) {
+        editorDOM.removeEventListener('blur', this.handleDomBlur);
+        this.onBlur(e);
+      }
+    }, 50);
+  };
+
   /*
    * Needs to be wrapped otherwise it causes issues because of race conditions
    * Known issue for slatejs. See: https://github.com/ianstormtaylor/slate/issues/2097
@@ -339,12 +359,8 @@ export class Editor extends React.Component {
        * is focused.
        */
       if (editorDOM === document.activeElement) {
-        const handleDomBlur = e => {
-          editorDOM.removeEventListener('blur', handleDomBlur);
-          this.onBlur(e);
-        };
-
-        editorDOM.addEventListener('blur', handleDomBlur);
+        editorDOM.removeEventListener('blur', this.handleDomBlur);
+        editorDOM.addEventListener('blur', this.handleDomBlur);
       }
 
       this.stashValue();
@@ -469,9 +485,10 @@ export class Editor extends React.Component {
      * HACK ALERT: We should be calling setState here and storing the change data:
      *
      * <code>this.setState({changeData: { key, data}})</code>
-     * However this is causing issues with the Mathquill instance. The 'input' event stops firing on the element and no more changes get through.
-     * The issues seem to be related to the promises in onBlur/onFocus. But removing these brings it's own problems.
-     * A major clean up is planned for this component so I've decided to temporarily settle on this hack rather than spend more time on this.
+     * However this is causing issues with the Mathquill instance. The 'input' event stops firing on the element and no
+     * more changes get through. The issues seem to be related to the promises in onBlur/onFocus. But removing these
+     * brings it's own problems. A major clean up is planned for this component so I've decided to temporarily settle
+     * on this hack rather than spend more time on this.
      */
 
     // Uncomment this line to see the bug described above.


### PR DESCRIPTION
fix(editor): made sure that if the editor loses focus, the onBlur function is called only if the focus is still not inside the dom element [PD-1126]