### PR TITLE
fix(editor): used dom refs in order to check if the editor is still in focus [PD-1126]

### DIFF
--- a/packages/editable-html/src/editor.jsx
+++ b/packages/editable-html/src/editor.jsx
@@ -311,8 +311,10 @@ export class Editor extends React.Component {
         return;
       }
 
-      const editorElement = document.activeElement.closest('[class*=editorHolder]');
-      const toolbarElement = document.activeElement.closest('[class*=Toolbar-focused]');
+      const editorElement =
+        !editorDOM || document.activeElement.closest(`[class*="${editorDOM.className}"]`);
+      const toolbarElement =
+        !this.toolbarRef || document.activeElement.closest(`[class*="${this.toolbarRef.className}"]`);
       const isInCurrentComponent =
         this.wrapperRef.contains(editorElement) || this.wrapperRef.contains(toolbarElement);
 
@@ -539,6 +541,11 @@ export class Editor extends React.Component {
             }
           }}
           ref={r => (this.editor = r && this.props.editorRef(r))}
+          toolbarRef={r => {
+            if (r) {
+              this.toolbarRef = r;
+            }
+          }}
           value={value}
           focus={this.focus}
           onKeyDown={onKeyDown}

--- a/packages/editable-html/src/plugins/toolbar/editor-and-toolbar.jsx
+++ b/packages/editable-html/src/plugins/toolbar/editor-and-toolbar.jsx
@@ -19,6 +19,7 @@ export class EditorAndToolbar extends React.Component {
     onChange: PropTypes.func.isRequired,
     onDone: PropTypes.func.isRequired,
     onDataChange: PropTypes.func,
+    toolbarRef: PropTypes.func,
     focusedNode: SlatePropTypes.node,
     readOnly: PropTypes.bool,
     disableUnderline: PropTypes.bool,
@@ -54,7 +55,8 @@ export class EditorAndToolbar extends React.Component {
       disableUnderline,
       pluginProps,
       toolbarOpts,
-      onDataChange
+      onDataChange,
+      toolbarRef
     } = this.props;
 
     const inFocus = value.isFocused || (focusedNode !== null && focusedNode !== undefined);
@@ -95,6 +97,7 @@ export class EditorAndToolbar extends React.Component {
           onChange={onChange}
           onDone={onDone}
           onDataChange={onDataChange}
+          toolbarRef={toolbarRef}
           pluginProps={pluginProps}
           toolbarOpts={toolbarOpts}
         />

--- a/packages/editable-html/src/plugins/toolbar/toolbar.jsx
+++ b/packages/editable-html/src/plugins/toolbar/toolbar.jsx
@@ -43,6 +43,7 @@ export class Toolbar extends React.Component {
     plugin: PropTypes.object,
     onImageClick: PropTypes.func,
     onDone: PropTypes.func.isRequired,
+    toolbarRef: PropTypes.func.isRequired,
     classes: PropTypes.object.isRequired,
     isFocused: PropTypes.bool,
     autoWidth: PropTypes.bool,
@@ -52,6 +53,7 @@ export class Toolbar extends React.Component {
       position: PropTypes.oneOf(['bottom', 'top']),
       alignment: PropTypes.oneOf(['left', 'right']),
       alwaysVisible: PropTypes.bool,
+      ref: PropTypes.obj,
       showDone: PropTypes.bool
     }),
     onDataChange: PropTypes.func
@@ -133,7 +135,8 @@ export class Toolbar extends React.Component {
       autoWidth,
       onChange,
       isFocused,
-      onDone
+      onDone,
+      toolbarRef
     } = this.props;
 
     const node = findSingleNode(value);
@@ -223,7 +226,7 @@ export class Toolbar extends React.Component {
     });
 
     return (
-      <div className={names} style={extraStyles} onClick={this.onClick}>
+      <div className={names} style={extraStyles} onClick={this.onClick} ref={toolbarRef}>
         {CustomToolbar ? (
           <CustomToolbar
             node={node}


### PR DESCRIPTION
fix(editor): used dom refs in order to check if the editor is still in focus [PD-1126]