### PR TITLE
fix(mask-markup): fix style for drag-in-the-blank image tokens PD-1351

### DIFF
--- a/packages/mask-markup/src/choices/choice.jsx
+++ b/packages/mask-markup/src/choices/choice.jsx
@@ -67,7 +67,11 @@ export const BlankContent = withStyles(theme => ({
     margin: '4px'
   },
   chipLabel: {
-    whiteSpace: 'pre-wrap'
+    whiteSpace: 'pre-wrap',
+    '& img': {
+      display: 'block',
+      padding: '2px 0'
+    }
   },
   disabled: {}
 }))(BlankContentComp);

--- a/packages/mask-markup/src/components/blank.jsx
+++ b/packages/mask-markup/src/components/blank.jsx
@@ -24,7 +24,11 @@ const useStyles = withStyles(() => ({
     position: 'relative'
   },
   chipLabel: {
-    whiteSpace: 'pre-wrap'
+    whiteSpace: 'pre-wrap',
+    '& img': {
+      display: 'block',
+      padding: '2px 0'
+    }
   },
   hidden: {
     color: 'transparent',


### PR DESCRIPTION
https://illuminate.atlassian.net/browse/PD-1351
image tokens are now centered and don't cover top border: 
![image](https://user-images.githubusercontent.com/61793308/139846446-bc9f4043-f04e-47a9-9b37-352d68e93d6e.png)
