### PR TITLE
fix(math-rendering): fix line spacing for mathjax mspace PD-1384

### DIFF
--- a/packages/math-rendering/src/render-math.js
+++ b/packages/math-rendering/src/render-math.js
@@ -196,7 +196,8 @@ const renderMath = (el, renderOpts) => {
 CHTMLmspace.styles = {
   'mjx-mspace': {
     display: 'block',
-    'text-align': 'center'
+    'text-align': 'center',
+    height: '5px'
   }
 };
 


### PR DESCRIPTION
https://illuminate.atlassian.net/browse/PD-1384
before:
![image](https://user-images.githubusercontent.com/61793308/141776280-3a530405-1319-4c31-b942-142aac9dc330.png)

after: 
![image](https://user-images.githubusercontent.com/61793308/141776256-57fac61c-40ea-4072-8ef0-24dbe5b3eb0e.png)
