### PR TITLE
fix(editable-html): Insert button from video/audio modal can't be pressed if the URL is empty PD-1488

### DIFF
--- a/packages/editable-html/src/plugins/media/media-dialog.js
+++ b/packages/editable-html/src/plugins/media/media-dialog.js
@@ -348,7 +348,7 @@ export class MediaDialog extends React.Component {
             Cancel
           </Button>
           <Button
-            disabled={invalid || url === null}
+            disabled={invalid || url === null || url === undefined}
             onClick={() => this.handleDone(true)}
             color="primary"
           >


### PR DESCRIPTION
https://illuminate.atlassian.net/browse/PD-1488