### PR TITLE
fix(mask-markup): render mathml correctly

### DIFF
--- a/packages/mask-markup/src/mask.jsx
+++ b/packages/mask-markup/src/mask.jsx
@@ -44,6 +44,13 @@ export const renderChildren = (layout, value, onChange, rootRenderChildren, pare
   (layout.nodes || []).forEach((n, index) => {
     const key = `${n.type}-${index}`;
 
+    if (n.isMath) {
+      children.push(
+        <span dangerouslySetInnerHTML={{ __html: `<math>${n.nodes[0].innerHTML}</math>` }} />
+      );
+      return children;
+    }
+
     if (rootRenderChildren) {
       const c = rootRenderChildren(n, value, onChange);
       if (c) {

--- a/packages/mask-markup/src/serialization.js
+++ b/packages/mask-markup/src/serialization.js
@@ -140,6 +140,13 @@ const rules = [
       const allAttrs = attributes.reduce(attributesToMap(el), { ...normalAttrs });
       const object = getObject(type);
 
+      if (el.tagName.toLowerCase() === 'math') {
+        return {
+          isMath: true,
+          nodes: [el]
+        };
+      }
+
       return {
         object,
         type,


### PR DESCRIPTION
Render mathml in a `dangerouslySetInnerHTML` property.

It seems `open` mathml property is being overwritten by React. Maybe it's worth to report this issue on React repo. 

Sources:
* https://github.com/facebook/react/issues/9320
* https://github.com/remarkablemark/html-react-parser/issues/301
* https://stackoverflow.com/questions/51319758/react-16-html-attributes-with-mathml-tags

Ticket: https://illuminate.atlassian.net/browse/PD-397 