### PR TITLE
fix(blank): made sure height is auto to adapt to content, until it is calculated [PD-1652]

### DIFF
--- a/packages/mask-markup/src/components/blank.jsx
+++ b/packages/mask-markup/src/components/blank.jsx
@@ -20,6 +20,7 @@ const useStyles = withStyles(() => ({
     minWidth: '90px',
     fontSize: 'inherit',
     minHeight: '32px',
+    height: 'auto',
     maxWidth: '374px',
     position: 'relative'
   },


### PR DESCRIPTION
https://illuminate.atlassian.net/browse/PD-1652

@sergiulucaci please look at this, I re-added  `height: auto` (added initially by @PatriciaRomaniuc)  which you removed, this fixes the height when the text is too long, the blank adjust to the content