### PR TITLE
feat(charting): remove editCategoryEnabled property checkbox and usage

### DIFF
--- a/packages/charting/src/__tests__/__snapshots__/axes.test.jsx.snap
+++ b/packages/charting/src/__tests__/__snapshots__/axes.test.jsx.snap
@@ -522,43 +522,6 @@ exports[`TickComponent snapshot1 renders 1`] = `
       }
       onChange={[Function]}
     />
-    <WithStyles(MarkLabel)
-      disabled={true}
-      graphProps={
-        Object {
-          "domain": Object {
-            "max": 1,
-            "min": 0,
-            "step": 1,
-          },
-          "range": Object {
-            "max": 1,
-            "min": 0,
-            "step": 1,
-          },
-          "scale": Object {
-            "x": [MockFunction],
-            "y": [MockFunction],
-          },
-          "size": Object {
-            "height": 400,
-            "width": 400,
-          },
-          "snap": Object {
-            "x": [MockFunction],
-            "y": [MockFunction],
-          },
-        }
-      }
-      inputRef={[Function]}
-      mark={
-        Object {
-          "label": "test",
-          "value": 1,
-        }
-      }
-      onChange={[Function]}
-    />
   </foreignObject>
 </g>
 `;

--- a/packages/charting/src/__tests__/__snapshots__/chart.test.jsx.snap
+++ b/packages/charting/src/__tests__/__snapshots__/chart.test.jsx.snap
@@ -134,7 +134,7 @@ exports[`ChartAxes snapshot renders 1`] = `
     >
       <rect
         fill="white"
-        height={150}
+        height={180}
         width={120}
         x={-10}
         y={-10}
@@ -317,7 +317,7 @@ exports[`ChartAxes snapshot renders if size is not defined 1`] = `
     >
       <rect
         fill="white"
-        height={530}
+        height={560}
         width={500}
         x={-10}
         y={-10}
@@ -502,7 +502,7 @@ exports[`ChartAxes snapshot renders without chartType and charts properties 1`] 
     >
       <rect
         fill="white"
-        height={150}
+        height={180}
         width={120}
         x={-10}
         y={-10}
@@ -685,7 +685,7 @@ exports[`ChartAxes snapshot renders without chartType property 1`] = `
     >
       <rect
         fill="white"
-        height={150}
+        height={180}
         width={120}
         x={-10}
         y={-10}

--- a/packages/charting/src/axes.jsx
+++ b/packages/charting/src/axes.jsx
@@ -31,6 +31,13 @@ export class TickComponent extends React.Component {
     onChangeCategory(index, { ...category, interactive: !category.interactive });
   };
 
+  changeEditable = (index, value) => {
+    const { categories, onChangeCategory } = this.props;
+    const category = categories[index];
+
+    onChangeCategory(index, { ...category, editable: !category.editable || false });
+  };
+
   render() {
     const {
       classes,
@@ -90,17 +97,7 @@ export class TickComponent extends React.Component {
           )}
           <MarkLabel
             inputRef={r => (this.input = r)}
-            disabled={!(editable && interactive)}
-            mark={category}
-            graphProps={graphProps}
-            onChange={newLabel => this.changeCategory(index, newLabel)}
-            barWidth={barWidth}
-            rotate={rotate}
-            correctness={correctness}
-          />
-          <MarkLabel
-            inputRef={r => (this.input = r)}
-            disabled={!(editable && interactive)}
+            disabled={!editable}
             mark={category}
             graphProps={graphProps}
             onChange={newLabel => this.changeCategory(index, newLabel)}
@@ -157,6 +154,31 @@ export class TickComponent extends React.Component {
             </tspan>
           </text>
         )}
+        {defineChart && index === 0 && (
+          <text
+            x={x - 80}
+            y={y + 80 + top}
+            width={barWidth}
+            height={4}
+            style={{
+              position: 'absolute',
+              pointerEvents: 'none',
+              wordBreak: 'break-word',
+              overflow: 'visible',
+              maxWidth: barWidth,
+              display: 'inline-block'
+            }}
+          >
+            <tspan x="0" dy=".6em">
+              {' '}
+              Student can{' '}
+            </tspan>
+            <tspan x="0" dy="1.2em">
+              {' '}
+              edit name
+            </tspan>
+          </text>
+        )}
         {defineChart && (
           <foreignObject
             x={x - 24}
@@ -168,6 +190,20 @@ export class TickComponent extends React.Component {
             <Checkbox
               checked={interactive}
               onChange={e => this.changeInteractive(index, e.target.checked)}
+            />
+          </foreignObject>
+        )}
+        {defineChart && (
+          <foreignObject
+            x={x - 24}
+            y={y + 70 + top}
+            width={barWidth}
+            height={4}
+            style={{ pointerEvents: 'visible', overflow: 'visible' }}
+          >
+            <Checkbox
+              checked={editable}
+              onChange={e => this.changeEditable(index, e.target.checked)}
             />
           </foreignObject>
         )}

--- a/packages/charting/src/chart.jsx
+++ b/packages/charting/src/chart.jsx
@@ -47,7 +47,6 @@ export class Chart extends React.Component {
     title: PropTypes.string,
     onDataChange: PropTypes.func,
     addCategoryEnabled: PropTypes.bool,
-    editCategoryEnabled: PropTypes.bool,
     categoryDefaultLabel: PropTypes.string,
     theme: PropTypes.object
   };
@@ -127,13 +126,12 @@ export class Chart extends React.Component {
   };
 
   getFilteredCategories = () => {
-    const { data, editCategoryEnabled, addCategoryEnabled } = this.props;
+    const { data, defineChart } = this.props;
 
     return data
       ? data.map(d => ({
           ...d,
-          editable: !d.initial || (d.initial && editCategoryEnabled),
-          deletable: !d.initial || (d.initial && addCategoryEnabled)
+          deletable: defineChart || d.deletable
         }))
       : [];
   };
@@ -150,6 +148,7 @@ export class Chart extends React.Component {
       theme
     } = this.props;
     let { chartType } = this.props;
+
     const defineChart = this.props.defineChart || false;
     const { width, height } = size || {};
 
@@ -177,9 +176,10 @@ export class Chart extends React.Component {
         () => this.rootNode
       )
     };
+
     log('[render] common:', common);
 
-    const maskSize = { x: -10, y: -10, width: width + 20, height: height + 50 };
+    const maskSize = { x: -10, y: -10, width: width + 20, height: height + 80 };
     const { scale } = common.graphProps;
     const xBand = dataToXBand(scale.x, categories, width, chartType);
 
@@ -190,7 +190,7 @@ export class Chart extends React.Component {
     const bandWidth = xBand.bandwidth();
     // for chartType "line", bandWidth will be 0, so we have to calculate it
     const barWidth = bandWidth || scale.x(correctValues.domain.max) / categories.length;
-    const increaseHeight = defineChart ? 50 : 0;
+    const increaseHeight = defineChart ? 80 : 0;
 
     // if there are many categories, we have to rotate their names in order to fit
     // and we have to add extra value on top of some items


### PR DESCRIPTION
BREAKING CHANGE: The editCategoryEnabled propery has been removed

- add “Student can edit name” checkboxes on Chart 1
- remove editCategoryEnabled property checkbox and usage
- editable remains a property of the root-level data element, controlled by “Student can edit name” checkboxes
- update snapshots

![image](https://user-images.githubusercontent.com/56835388/173281815-80a7ed04-62d6-44c2-b514-c3b298a35a98.png)
