### PR TITLE
fix/PD-1723-B-C

### DIFF
--- a/packages/charting/src/__tests__/__snapshots__/chart.test.jsx.snap
+++ b/packages/charting/src/__tests__/__snapshots__/chart.test.jsx.snap
@@ -146,6 +146,7 @@ exports[`ChartAxes snapshot renders 1`] = `
     >
       <Component
         data={Array []}
+        defineChart={false}
         graphProps={
           Object {
             "domain": Object {
@@ -329,6 +330,7 @@ exports[`ChartAxes snapshot renders if size is not defined 1`] = `
     >
       <Component
         data={Array []}
+        defineChart={false}
         graphProps={
           Object {
             "domain": Object {
@@ -514,6 +516,7 @@ exports[`ChartAxes snapshot renders without chartType and charts properties 1`] 
     >
       <Bar
         data={Array []}
+        defineChart={false}
         graphProps={
           Object {
             "domain": Object {
@@ -697,6 +700,7 @@ exports[`ChartAxes snapshot renders without chartType property 1`] = `
     >
       <Component
         data={Array []}
+        defineChart={false}
         graphProps={
           Object {
             "domain": Object {

--- a/packages/charting/src/axes.jsx
+++ b/packages/charting/src/axes.jsx
@@ -97,7 +97,7 @@ export class TickComponent extends React.Component {
           )}
           <MarkLabel
             inputRef={r => (this.input = r)}
-            disabled={!editable}
+            disabled={defineChart ? false : !editable}
             mark={category}
             graphProps={graphProps}
             onChange={newLabel => this.changeCategory(index, newLabel)}

--- a/packages/charting/src/bars/common/bars.jsx
+++ b/packages/charting/src/bars/common/bars.jsx
@@ -65,6 +65,7 @@ export class RawBar extends React.Component {
       interactive,
       correctness
     } = this.props;
+
     const { scale, range } = graphProps;
     const { dragValue } = this.state;
 
@@ -117,13 +118,14 @@ export class Bars extends React.Component {
   };
 
   render() {
-    const { data, graphProps, xBand, onChangeCategory } = this.props;
+    const { data, graphProps, xBand, onChangeCategory, defineChart } = this.props;
+
     return (
       <Group>
         {(data || []).map((d, index) => (
           <Bar
             value={d.value}
-            interactive={d.interactive}
+            interactive={defineChart ? true : d.interactive}
             label={d.label}
             xBand={xBand}
             index={index}

--- a/packages/charting/src/bars/common/bars.jsx
+++ b/packages/charting/src/bars/common/bars.jsx
@@ -113,6 +113,7 @@ export class Bars extends React.Component {
   static propTypes = {
     data: PropTypes.array,
     onChangeCategory: PropTypes.func,
+    defineChart: PropTypes.bool,
     xBand: PropTypes.func,
     graphProps: types.GraphPropsType.isRequired
   };

--- a/packages/charting/src/chart.jsx
+++ b/packages/charting/src/chart.jsx
@@ -231,6 +231,7 @@ export class Chart extends React.Component {
             <ChartComponent
               {...common}
               data={categories}
+              defineChart={defineChart}
               onChange={this.changeData}
               onChangeCategory={this.changeCategory}
             />

--- a/packages/charting/src/chart.jsx
+++ b/packages/charting/src/chart.jsx
@@ -48,6 +48,7 @@ export class Chart extends React.Component {
     onDataChange: PropTypes.func,
     addCategoryEnabled: PropTypes.bool,
     categoryDefaultLabel: PropTypes.string,
+    defineChart: PropTypes.bool,
     theme: PropTypes.object
   };
 

--- a/packages/charting/src/line/common/drag-handle.jsx
+++ b/packages/charting/src/line/common/drag-handle.jsx
@@ -34,6 +34,7 @@ class RawDragHandle extends React.Component {
       correctness,
       ...rest
     } = this.props;
+
     const { scale } = graphProps;
     return (
       <CustomDraggableComponent
@@ -42,7 +43,7 @@ class RawDragHandle extends React.Component {
         y={y}
         classes={classes}
         className={classNames(className, !interactive && 'non-interactive')}
-        correctness={interactive && correctness}
+        correctness={correctness}
         {...rest}
       />
     );

--- a/packages/charting/src/line/common/line.jsx
+++ b/packages/charting/src/line/common/line.jsx
@@ -32,6 +32,7 @@ export class RawLine extends React.Component {
     xBand: PropTypes.func,
     index: PropTypes.number.isRequired,
     graphProps: types.GraphPropsType.isRequired,
+    defineChart: PropTypes.bool,
     data: PropTypes.arrayOf(
       PropTypes.shape({
         label: PropTypes.string,

--- a/packages/charting/src/line/common/line.jsx
+++ b/packages/charting/src/line/common/line.jsx
@@ -77,7 +77,7 @@ export class RawLine extends React.Component {
   };
 
   render() {
-    const { graphProps, data, classes, CustomDraggableComponent } = this.props;
+    const { graphProps, data, classes, CustomDraggableComponent, defineChart } = this.props;
     const { line: lineState, dragging } = this.state;
     const { scale } = graphProps;
     const lineToUse = dragging ? lineState : getData(data, graphProps.domain);
@@ -93,14 +93,15 @@ export class RawLine extends React.Component {
         {lineToUse &&
           lineToUse.map((point, i) => {
             const r = 6;
-            const Component = point.interactive ? DraggableHandle : DragHandle;
+            const enableDraggable = defineChart ? true : point.interactive;
+            const Component = enableDraggable ? DraggableHandle : DragHandle;
 
             return (
               <Component
                 key={`point-${point.x}-${i}`}
                 x={point.x}
                 y={point.dragValue !== undefined ? point.dragValue : point.y}
-                interactive={point.interactive}
+                interactive={enableDraggable}
                 r={r}
                 onDragStart={() => this.setState({ dragging: true })}
                 onDrag={v =>

--- a/packages/charting/src/plot/common/plot.jsx
+++ b/packages/charting/src/plot/common/plot.jsx
@@ -141,7 +141,7 @@ export class Plot extends React.Component {
   };
 
   render() {
-    const { data, graphProps, xBand, CustomBarElement, onChangeCategory } = this.props;
+    const { data, graphProps, xBand, CustomBarElement, onChangeCategory, defineChart } = this.props;
 
     return (
       <Group>
@@ -149,7 +149,7 @@ export class Plot extends React.Component {
           <Bar
             value={d.value}
             label={d.label}
-            interactive={d.interactive}
+            interactive={defineChart ? true : d.interactive}
             xBand={xBand}
             index={index}
             key={`bar-${d.label}-${d.value}-${index}`}

--- a/packages/charting/src/plot/common/plot.jsx
+++ b/packages/charting/src/plot/common/plot.jsx
@@ -137,6 +137,7 @@ export class Plot extends React.Component {
     onChangeCategory: PropTypes.func,
     xBand: PropTypes.func,
     graphProps: types.GraphPropsType.isRequired,
+    defineChart: PropTypes.bool,
     CustomBarElement: PropTypes.func
   };
 

--- a/packages/charting/src/plot/common/plot.jsx
+++ b/packages/charting/src/plot/common/plot.jsx
@@ -67,6 +67,7 @@ export class RawPlot extends React.Component {
       interactive,
       correctness
     } = this.props;
+
     const { scale, range, size } = graphProps;
     const { max } = range || {};
     const { dragValue } = this.state;


### PR DESCRIPTION
- categories label should always be editable in Chart1 configuration
- categories should always be interactive in Chart1 configuration
- update snapshots
- fix some propTypes warnings