### PR TITLE
feat(editable-html & math-toolbar & math-rendering) Overwrite mathquill font

### DIFF
--- a/packages/editable-html/src/editor.jsx
+++ b/packages/editable-html/src/editor.jsx
@@ -714,7 +714,30 @@ const styles = {
     },
     '& table:not([border="1"]) td, th': {
       border: '1px solid #dfe2e5'
-    }
+    },
+    '& .RawMathPreview-root-143 *': {
+      fontFamily: 'MJXZERO, MJXTEX !important'
+    },
+    '& .mq-math-mode var, .mq-math-mode i, .mq-math-mode i.mq-font': {
+      fontFamily: 'MJXZERO, MJXTEX-I !important'
+    },
+    '& .mq-math-mode .mq-sqrt-stem': {
+      borderTop: '0.07em solid',
+      marginLeft: '-1.5px',
+      marginTop: '-2px !important',
+      paddingTop: '5px !important'
+    },
+    '& .mq-supsub ': {
+      fontSize: '70.7%'
+    },
+    '& .mq-math-mode .mq-supsub.mq-sup-only': {
+      verticalAlign: '-0.1em !important',
+
+      '& .mq-sup': {
+        marginBottom: '0px !important'
+      }
+    },
+    '-webkit-font-smoothing': 'antialiased !important'
   },
   toolbarOnTop: {
     marginTop: '45px'

--- a/packages/math-input/src/keypad/index.jsx
+++ b/packages/math-input/src/keypad/index.jsx
@@ -40,14 +40,17 @@ const LatexButton = withStyles(theme => ({
       width: '30px',
       marginTop: '0 !important',
       borderTop: '2px solid black',
+      fontFamily: 'Roboto, Helvetica, Arial, sans-serif !important',
+
       '&.mq-arrow-both': {
+        top: '5px !important',
         '& *': {
           lineHeight: '1 !important'
         },
         '&:before': {
           fontSize: '80%',
           left: 'calc(-13%)',
-          top: '-0.25em'
+          top: '-0.31em'
         },
         '&:after': {
           fontSize: '80% !important',
@@ -123,7 +126,7 @@ const LatexButton = withStyles(theme => ({
         paddingTop: '0 !important'
       },
       '&:after': {
-        top: '-1.64em !important'
+        top: '-2.8em !important'
       }
     }
   }

--- a/packages/math-input/src/keypad/index.jsx
+++ b/packages/math-input/src/keypad/index.jsx
@@ -60,12 +60,12 @@ const LatexButton = withStyles(theme => ({
         '&.mq-empty:before': {
           fontSize: '80%',
           left: 'calc(-13%)',
-          top: '-0.25em'
+          top: '-0.26em'
         },
         '&.mq-empty:after': {
           fontSize: '80%',
           right: 'calc(-13%)',
-          top: '-0.25em'
+          top: '-0.26em'
         },
         '&.mq-empty': {
           minHeight: '1.4em'

--- a/packages/math-rendering/src/mstack/chtml.js
+++ b/packages/math-rendering/src/mstack/chtml.js
@@ -211,5 +211,8 @@ CHTMLmstack.styles = {
   'mjx-mstack > table > tr > .mjx-line': {
     padding: 0,
     'border-top': 'solid 1px black'
+  },
+  '.TEX-A': {
+    'font-family': 'MJXZERO, MJXTEX !important'
   }
 };

--- a/packages/math-toolbar/src/editor-and-pad.jsx
+++ b/packages/math-toolbar/src/editor-and-pad.jsx
@@ -277,7 +277,11 @@ const styles = theme => ({
   inputAndTypeContainer: {
     display: 'flex',
     alignItems: 'center',
-    '& *': {
+    '& .mq-root-block': {
+      marginTop: '8px',
+      overflow: 'visible'
+    },
+    '& .mq-math-mode .mq-overarrow': {
       fontFamily: 'Roboto, Helvetica, Arial, sans-serif !important'
     },
     '& .mq-overarrow.mq-arrow-both': {
@@ -302,6 +306,55 @@ const styles = theme => ({
         top: '-0.4em',
         right: '-1px'
       }
+    },
+    '& *': {
+      fontFamily: 'MJXZERO, MJXTEX-I !important',
+
+      '& .mq-math-mode .mq-empty': {
+        padding: '9px 1px !important'
+      },
+
+      '& .mq-longdiv-inner': {
+        marginTop: '-1px',
+        marginLeft: '5px !important;',
+
+        '& > .mq-empty': {
+          padding: '0 !important',
+          marginLeft: '0px !important',
+          marginTop: '2px'
+        }
+      },
+
+      '& .mq-math-mode .mq-longdiv': {
+        display: 'flex !important'
+      },
+
+      '& .mq-math-mode .mq-supsub': {
+        fontSize: '70.7% !important'
+      },
+
+      '& .mq-math-mode .mq-paren': {
+        verticalAlign: 'middle !important'
+      },
+
+      '& .mq-math-mode .mq-sqrt-stem': {
+        borderTop: '0.07em solid',
+        marginLeft: '-1.5px',
+        marginTop: '-2px !important',
+        paddingTop: '5px !important'
+      },
+      '& .mq-supsub ': {
+        fontSize: '70.7%'
+      },
+      '& .mq-math-mode .mq-supsub.mq-sup-only': {
+        verticalAlign: '-0.1em !important',
+
+        '& .mq-sup': {
+          marginBottom: '0px !important'
+        }
+      },
+
+      '-webkit-font-smoothing': 'antialiased !important'
     }
   },
   hide: {
@@ -314,7 +367,15 @@ const styles = theme => ({
     marginLeft: '15px',
     marginTop: '5px',
     marginBottom: '5px',
-    marginRight: '5px'
+    marginRight: '5px',
+    fontFamily: 'Roboto, Helvetica, Arial, sans-serif !important',
+
+    '& label': {
+      fontFamily: 'Roboto, Helvetica, Arial, sans-serif !important'
+    },
+    '& div': {
+      fontFamily: 'Roboto, Helvetica, Arial, sans-serif !important'
+    }
   },
   mathEditor: {
     maxWidth: '400px',

--- a/packages/math-toolbar/src/editor-and-pad.jsx
+++ b/packages/math-toolbar/src/editor-and-pad.jsx
@@ -260,6 +260,7 @@ export class EditorAndPad extends React.Component {
         <hr className={classes.hr} />
         {shouldShowKeypad && (
           <HorizontalKeypad
+            className={classes.keyboard}
             layoutForKeyPad={layoutForKeyPad}
             additionalKeys={additionalKeys}
             mode={controlledKeypadMode ? this.state.equationEditor : keypadMode}
@@ -382,6 +383,43 @@ const styles = theme => ({
   },
   error: {
     border: '2px solid red'
+  },
+  keyboard: {
+    '& *': {
+      fontFamily: 'MJXZERO, MJXTEX-I !important',
+
+      '& .mq-math-mode .mq-empty': {
+        padding: '9px 1px !important'
+      },
+
+      '& .mq-longdiv-inner': {
+        marginTop: '-1px',
+        marginLeft: '5px !important;',
+
+        '& > .mq-empty': {
+          padding: '0 !important',
+          marginLeft: '0px !important',
+          marginTop: '2px'
+        }
+      },
+
+      '& .mq-math-mode .mq-longdiv': {
+        display: 'flex !important'
+      },
+
+      '& .mq-math-mode .mq-supsub': {
+        fontSize: '70.7% !important'
+      },
+
+      '& .mq-math-mode .mq-sqrt-stem': {
+        marginTop: '-5px',
+        paddingTop: '4px'
+      },
+
+      '& .mq-math-mode .mq-paren': {
+        verticalAlign: 'middle !important'
+      }
+    }
   }
 });
 

--- a/packages/math-toolbar/src/editor-and-pad.jsx
+++ b/packages/math-toolbar/src/editor-and-pad.jsx
@@ -279,7 +279,6 @@ const styles = theme => ({
     alignItems: 'center',
     '& .mq-root-block': {
       marginTop: '8px',
-      overflow: 'visible'
     },
     '& .mq-math-mode .mq-overarrow': {
       fontFamily: 'Roboto, Helvetica, Arial, sans-serif !important'

--- a/packages/math-toolbar/src/editor-and-pad.jsx
+++ b/packages/math-toolbar/src/editor-and-pad.jsx
@@ -342,9 +342,11 @@ const styles = theme => ({
         marginTop: '-2px !important',
         paddingTop: '5px !important'
       },
+
       '& .mq-supsub ': {
         fontSize: '70.7%'
       },
+
       '& .mq-math-mode .mq-supsub.mq-sup-only': {
         verticalAlign: '-0.1em !important',
 
@@ -367,11 +369,11 @@ const styles = theme => ({
     marginTop: '5px',
     marginBottom: '5px',
     marginRight: '5px',
-    fontFamily: 'Roboto, Helvetica, Arial, sans-serif !important',
 
     '& label': {
       fontFamily: 'Roboto, Helvetica, Arial, sans-serif !important'
     },
+
     '& div': {
       fontFamily: 'Roboto, Helvetica, Arial, sans-serif !important'
     }


### PR DESCRIPTION
Tackles https://illuminate.atlassian.net/browse/PD-1521.

We're overwriting mathquill to be inline with mathjax. 

We're not covering everything but we just wanna fix the bad looking math rendering (you can check ticket's comments). 

I'm not so confident about the changes tbh, that's why I'm asking @andreeapescar & @andreeimiron to test & report what looks odd.

Thanks!
