### PR TITLE
fix(editable-html): fix paste text PD-1899

### DIFF
--- a/packages/editable-html/package.json
+++ b/packages/editable-html/package.json
@@ -29,6 +29,7 @@
     "slate-edit-list": "^0.11.3",
     "slate-edit-table": "^0.17.0",
     "slate-html-serializer": "^0.6.12",
+    "slate-plain-serializer": "^0.5.26",
     "slate-prop-types": "^0.4.38",
     "slate-react": "^0.14.3",
     "slate-schema-violations": "^0.1.39",


### PR DESCRIPTION
https://illuminate.atlassian.net/browse/PD-1899

Because in this slate version returning true or calling `next()` in `onPaste` method Slate does not execute its own event handler, in case type of paste transfer is not an image we use the default `onPaste` code from slate, which can be found under slate-react/lib/slate-react.es.js line 3221 (slate-react@0.14.3).