### PR TITLE
feat(editable-html & math-toolbar & math-rendering) Overwrite mathquill font

### DIFF
--- a/packages/editable-html/src/editor.jsx
+++ b/packages/editable-html/src/editor.jsx
@@ -715,29 +715,6 @@ const styles = {
     '& table:not([border="1"]) td, th': {
       border: '1px solid #dfe2e5'
     },
-    '& .RawMathPreview-root-143 *': {
-      fontFamily: 'MJXZERO, MJXTEX !important'
-    },
-    '& .mq-math-mode var, .mq-math-mode i, .mq-math-mode i.mq-font': {
-      fontFamily: 'MJXZERO, MJXTEX !important'
-    },
-    '& .mq-math-mode .mq-sqrt-stem': {
-      borderTop: '0.07em solid',
-      marginLeft: '-1.5px',
-      marginTop: '-2px !important',
-      paddingTop: '5px !important'
-    },
-    '& .mq-supsub ': {
-      fontSize: '70.7%'
-    },
-    '& .mq-math-mode .mq-supsub.mq-sup-only': {
-      verticalAlign: '-0.1em !important',
-
-      '& .mq-sup': {
-        marginBottom: '0px !important'
-      }
-    },
-    '-webkit-font-smoothing': 'antialiased !important'
   },
   toolbarOnTop: {
     marginTop: '45px'

--- a/packages/editable-html/src/editor.jsx
+++ b/packages/editable-html/src/editor.jsx
@@ -731,7 +731,7 @@ const styles = {
       fontSize: '70.7%'
     },
     '& .mq-math-mode .mq-supsub.mq-sup-only': {
-      verticalAlign: '0.4em !important',
+      verticalAlign: '-0.1em !important',
 
       '& .mq-sup': {
         marginBottom: '0px !important'

--- a/packages/editable-html/src/editor.jsx
+++ b/packages/editable-html/src/editor.jsx
@@ -714,7 +714,30 @@ const styles = {
     },
     '& table:not([border="1"]) td, th': {
       border: '1px solid #dfe2e5'
-    }
+    },
+    '& .RawMathPreview-root-143 *': {
+      fontFamily: 'MJXZERO, MJXTEX !important'
+    },
+    '& .mq-math-mode var, .mq-math-mode i, .mq-math-mode i.mq-font': {
+      fontFamily: 'MJXZERO, MJXTEX-I !important'
+    },
+    '& .mq-math-mode .mq-sqrt-stem': {
+      borderTop: '0.07em solid',
+      marginLeft: '-1.5px',
+      marginTop: '-2px !important',
+      paddingTop: '5px !important'
+    },
+    '& .mq-supsub ': {
+      fontSize: '70.7%'
+    },
+    '& .mq-math-mode .mq-supsub.mq-sup-only': {
+      verticalAlign: '0.4em !important',
+
+      '& .mq-sup': {
+        marginBottom: '0px !important'
+      }
+    },
+    '-webkit-font-smoothing': 'antialiased !important'
   },
   toolbarOnTop: {
     marginTop: '45px'

--- a/packages/editable-html/src/editor.jsx
+++ b/packages/editable-html/src/editor.jsx
@@ -714,7 +714,7 @@ const styles = {
     },
     '& table:not([border="1"]) td, th': {
       border: '1px solid #dfe2e5'
-    },
+    }
   },
   toolbarOnTop: {
     marginTop: '45px'

--- a/packages/editable-html/src/editor.jsx
+++ b/packages/editable-html/src/editor.jsx
@@ -719,7 +719,7 @@ const styles = {
       fontFamily: 'MJXZERO, MJXTEX !important'
     },
     '& .mq-math-mode var, .mq-math-mode i, .mq-math-mode i.mq-font': {
-      fontFamily: 'MJXZERO, MJXTEX-I !important'
+      fontFamily: 'MJXZERO, MJXTEX !important'
     },
     '& .mq-math-mode .mq-sqrt-stem': {
       borderTop: '0.07em solid',

--- a/packages/math-input/src/keypad/index.jsx
+++ b/packages/math-input/src/keypad/index.jsx
@@ -40,14 +40,17 @@ const LatexButton = withStyles(theme => ({
       width: '30px',
       marginTop: '0 !important',
       borderTop: '2px solid black',
+      fontFamily: 'Roboto, Helvetica, Arial, sans-serif !important',
+
       '&.mq-arrow-both': {
+        top: '5px !important',
         '& *': {
           lineHeight: '1 !important'
         },
         '&:before': {
           fontSize: '80%',
           left: 'calc(-13%)',
-          top: '-0.25em'
+          top: '-0.31em'
         },
         '&:after': {
           fontSize: '80% !important',
@@ -57,12 +60,12 @@ const LatexButton = withStyles(theme => ({
         '&.mq-empty:before': {
           fontSize: '80%',
           left: 'calc(-13%)',
-          top: '-0.25em'
+          top: '-0.26em'
         },
         '&.mq-empty:after': {
           fontSize: '80%',
           right: 'calc(-13%)',
-          top: '-0.25em'
+          top: '-0.26em'
         },
         '&.mq-empty': {
           minHeight: '1.4em'
@@ -123,7 +126,7 @@ const LatexButton = withStyles(theme => ({
         paddingTop: '0 !important'
       },
       '&:after': {
-        top: '-1.64em !important'
+        top: '-2.8em !important'
       }
     }
   }

--- a/packages/math-input/src/keypad/index.jsx
+++ b/packages/math-input/src/keypad/index.jsx
@@ -126,7 +126,7 @@ const LatexButton = withStyles(theme => ({
         paddingTop: '0 !important'
       },
       '&:after': {
-        top: '-2.8em !important'
+        top: '-1.94em !important'
       }
     }
   }

--- a/packages/math-input/src/keypad/index.jsx
+++ b/packages/math-input/src/keypad/index.jsx
@@ -74,7 +74,7 @@ const LatexButton = withStyles(theme => ({
       '&.mq-arrow-right:before': {
         fontSize: '80%',
         right: 'calc(-13%)',
-        top: '-0.25em'
+        top: '-0.26em'
       },
       '& .mq-overarrow-inner': {
         border: 'none !important'

--- a/packages/math-rendering/src/mstack/chtml.js
+++ b/packages/math-rendering/src/mstack/chtml.js
@@ -211,5 +211,8 @@ CHTMLmstack.styles = {
   'mjx-mstack > table > tr > .mjx-line': {
     padding: 0,
     'border-top': 'solid 1px black'
+  },
+  '.TEX-A': {
+    'font-family': 'MJXZERO, MJXTEX !important'
   }
 };

--- a/packages/math-toolbar/src/editor-and-pad.jsx
+++ b/packages/math-toolbar/src/editor-and-pad.jsx
@@ -325,6 +325,10 @@ const styles = theme => ({
         padding: '9px 1px !important'
       },
 
+      '& .mq-math-mode .mq-root-block': {
+        paddingTop: '6px'
+      },
+
       '& .mq-longdiv-inner': {
         marginTop: '-1px',
         marginLeft: '5px !important;',
@@ -395,7 +399,7 @@ const styles = theme => ({
     maxWidth: '400px',
     color: color.text(),
     backgroundColor: color.background(),
-    padding: theme.spacing.unit
+    padding: '2px'
   },
   longMathEditor: {
     maxWidth: '500px'

--- a/packages/math-toolbar/src/editor-and-pad.jsx
+++ b/packages/math-toolbar/src/editor-and-pad.jsx
@@ -293,8 +293,8 @@ const styles = theme => ({
         left: '-1px'
       },
       '&:after': {
-        top: '-2.36em',
-        right: '-1px'
+        top: '-3.15em',
+        right: '-2px'
       },
       '&.mq-empty:after': {
         top: '-0.45em'
@@ -341,7 +341,13 @@ const styles = theme => ({
       },
 
       '& .mq-math-mode .mq-longdiv': {
-        display: 'flex !important'
+        display: 'inline-flex !important'
+      },
+
+      '& .mq-math-mode .mq-longdiv .mq-longdiv-inner': {
+        marginLeft: '4px !important',
+        paddingTop: '6px !important',
+        paddingLeft: '6px !important'
       },
 
       '& .mq-math-mode .mq-supsub': {
@@ -487,7 +493,7 @@ const styles = theme => ({
       },
 
       '& .mq-math-mode .mq-longdiv': {
-        display: 'flex !important'
+        display: 'inline-flex !important'
       },
 
       '& .mq-math-mode .mq-supsub': {

--- a/packages/math-toolbar/src/editor-and-pad.jsx
+++ b/packages/math-toolbar/src/editor-and-pad.jsx
@@ -315,6 +315,19 @@ const styles = theme => ({
     '& *': {
       fontFamily: 'MJXZERO, MJXTEX !important',
 
+      '& .mq-math-mode > span > var': {
+        fontFamily: 'MJXZERO, MJXTEX-I !important'
+      },
+      '& .mq-math-mode span var': {
+        fontFamily: 'MJXZERO, MJXTEX-I !important'
+      },
+      '& .mq-math-mode .mq-nonSymbola': {
+        fontFamily: 'MJXZERO, MJXTEX-I !important'
+      },
+      '& .mq-math-mode > span > var.mq-operator-name': {
+        fontFamily: 'MJXZERO, MJXTEX !important'
+      },
+
       '& .mq-math-mode .mq-sqrt-prefix': {
         verticalAlign: 'bottom !important',
         top: '0 !important',
@@ -503,6 +516,19 @@ const styles = theme => ({
   keyboard: {
     '& *': {
       fontFamily: 'MJXZERO, MJXTEX !important',
+
+      '& .mq-math-mode > span > var': {
+        fontFamily: 'MJXZERO, MJXTEX-I !important'
+      },
+      '& .mq-math-mode span var': {
+        fontFamily: 'MJXZERO, MJXTEX-I !important'
+      },
+      '& .mq-math-mode .mq-nonSymbola': {
+        fontFamily: 'MJXZERO, MJXTEX-I !important'
+      },
+      '& .mq-math-mode > span > var.mq-operator-name': {
+        fontFamily: 'MJXZERO, MJXTEX !important'
+      },
 
       '& .mq-math-mode .mq-sqrt-prefix': {
         top: '0 !important'

--- a/packages/math-toolbar/src/editor-and-pad.jsx
+++ b/packages/math-toolbar/src/editor-and-pad.jsx
@@ -260,6 +260,7 @@ export class EditorAndPad extends React.Component {
         <hr className={classes.hr} />
         {shouldShowKeypad && (
           <HorizontalKeypad
+            className={classes.keyboard}
             layoutForKeyPad={layoutForKeyPad}
             additionalKeys={additionalKeys}
             mode={controlledKeypadMode ? this.state.equationEditor : keypadMode}
@@ -276,7 +277,10 @@ const styles = theme => ({
   inputAndTypeContainer: {
     display: 'flex',
     alignItems: 'center',
-    '& *': {
+    '& .mq-root-block': {
+      marginTop: '8px'
+    },
+    '& .mq-math-mode .mq-overarrow': {
       fontFamily: 'Roboto, Helvetica, Arial, sans-serif !important'
     },
     '& .mq-overarrow.mq-arrow-both': {
@@ -301,6 +305,70 @@ const styles = theme => ({
         top: '-0.4em',
         right: '-1px'
       }
+    },
+    '& *': {
+      fontFamily: 'MJXZERO, MJXTEX-I !important',
+
+      '& .mq-math-mode .mq-sqrt-prefix': {
+        verticalAlign: 'bottom !important',
+        top: '0.2em !important',
+        left: '-0.1em !important'
+      },
+
+      '& .mq-math-mode sup.mq-nthroot': {
+        fontSize: '70% !important',
+        verticalAlign: '0.5em !important',
+        paddingRight: '0.15em'
+      },
+
+      '& .mq-math-mode .mq-empty': {
+        padding: '9px 1px !important'
+      },
+
+      '& .mq-longdiv-inner': {
+        marginTop: '-1px',
+        marginLeft: '5px !important;',
+
+        '& > .mq-empty': {
+          padding: '0 !important',
+          marginLeft: '0px !important',
+          marginTop: '2px'
+        }
+      },
+
+      '& .mq-math-mode .mq-longdiv': {
+        display: 'flex !important'
+      },
+
+      '& .mq-math-mode .mq-supsub': {
+        fontSize: '70.7% !important'
+      },
+
+      '& .mq-math-mode .mq-paren': {
+        verticalAlign: 'top !important',
+        padding: '4px 0.1em !important'
+      },
+
+      '& .mq-math-mode .mq-sqrt-stem': {
+        borderTop: '0.07em solid',
+        marginLeft: '-1.5px',
+        marginTop: '-2px !important',
+        paddingTop: '5px !important'
+      },
+
+      '& .mq-supsub ': {
+        fontSize: '70.7%'
+      },
+
+      '& .mq-math-mode .mq-supsub.mq-sup-only': {
+        verticalAlign: '-0.1em !important',
+
+        '& .mq-sup': {
+          marginBottom: '0px !important'
+        }
+      },
+
+      '-webkit-font-smoothing': 'antialiased !important'
     }
   },
   hide: {
@@ -313,7 +381,15 @@ const styles = theme => ({
     marginLeft: '15px',
     marginTop: '5px',
     marginBottom: '5px',
-    marginRight: '5px'
+    marginRight: '5px',
+
+    '& label': {
+      fontFamily: 'Roboto, Helvetica, Arial, sans-serif !important'
+    },
+
+    '& div': {
+      fontFamily: 'Roboto, Helvetica, Arial, sans-serif !important'
+    }
   },
   mathEditor: {
     maxWidth: '400px',
@@ -378,10 +454,51 @@ const styles = theme => ({
     width: '100%',
     display: 'flex',
     marginTop: theme.spacing.unit,
-    marginBottom: theme.spacing.unit
+    marginBottom: theme.spacing.unit,
+
+    '& .mq-sqrt-prefix .mq-scaled': {
+      verticalAlign: 'middle !important'
+    }
   },
   error: {
     border: '2px solid red'
+  },
+  keyboard: {
+    '& *': {
+      fontFamily: 'MJXZERO, MJXTEX-I !important',
+
+      '& .mq-math-mode .mq-empty': {
+        padding: '9px 1px !important'
+      },
+
+      '& .mq-longdiv-inner': {
+        marginTop: '-1px',
+        marginLeft: '5px !important;',
+
+        '& > .mq-empty': {
+          padding: '0 !important',
+          marginLeft: '0px !important',
+          marginTop: '2px'
+        }
+      },
+
+      '& .mq-math-mode .mq-longdiv': {
+        display: 'flex !important'
+      },
+
+      '& .mq-math-mode .mq-supsub': {
+        fontSize: '70.7% !important'
+      },
+
+      '& .mq-math-mode .mq-sqrt-stem': {
+        marginTop: '-5px',
+        paddingTop: '4px'
+      },
+
+      '& .mq-math-mode .mq-paren': {
+        verticalAlign: 'middle !important'
+      }
+    }
   }
 });
 

--- a/packages/math-toolbar/src/editor-and-pad.jsx
+++ b/packages/math-toolbar/src/editor-and-pad.jsx
@@ -277,11 +277,17 @@ const styles = theme => ({
   inputAndTypeContainer: {
     display: 'flex',
     alignItems: 'center',
-    '& .mq-root-block': {
-      marginTop: '8px'
+    '& .mq-editable-field .mq-cursor': {
+      top: '-4px'
+    },
+    '& .mq-math-mode .mq-selection, .mq-editable-field .mq-selection': {
+      paddingTop: '18px'
     },
     '& .mq-math-mode .mq-overarrow': {
       fontFamily: 'Roboto, Helvetica, Arial, sans-serif !important'
+    },
+    '& .mq-math-mode .mq-overline .mq-overline-inner': {
+      paddingTop: '0.4em !important'
     },
     '& .mq-overarrow.mq-arrow-both': {
       minWidth: '1.23em',
@@ -307,11 +313,11 @@ const styles = theme => ({
       }
     },
     '& *': {
-      fontFamily: 'MJXZERO, MJXTEX-I !important',
+      fontFamily: 'MJXZERO, MJXTEX !important',
 
       '& .mq-math-mode .mq-sqrt-prefix': {
         verticalAlign: 'bottom !important',
-        top: '0.2em !important',
+        top: '0 !important',
         left: '-0.1em !important'
       },
 
@@ -326,7 +332,11 @@ const styles = theme => ({
       },
 
       '& .mq-math-mode .mq-root-block': {
-        paddingTop: '6px'
+        paddingTop: '10px'
+      },
+
+      '& .mq-scaled .mq-sqrt-prefix': {
+        top: '0 !important'
       },
 
       '& .mq-longdiv-inner': {
@@ -356,7 +366,7 @@ const styles = theme => ({
 
       '& .mq-math-mode .mq-paren': {
         verticalAlign: 'top !important',
-        padding: '4px 0.1em !important'
+        padding: '1px 0.1em !important'
       },
 
       '& .mq-math-mode .mq-sqrt-stem': {
@@ -376,6 +386,17 @@ const styles = theme => ({
         '& .mq-sup': {
           marginBottom: '0px !important'
         }
+      },
+
+      '& .mq-math-mode .mq-denominator': {
+        marginTop: '-5px !important',
+        padding: '0.5em 0.1em 0.1em !important'
+      },
+
+      '& .mq-math-mode .mq-numerator, .mq-math-mode .mq-over': {
+        padding: '0 0.1em !important',
+        paddingBottom: '0 !important',
+        marginBottom: '4.5px'
       },
 
       '-webkit-font-smoothing': 'antialiased !important'
@@ -451,6 +472,8 @@ const styles = theme => ({
       paddingTop: '1.5px !important'
     },
     '& .mq-overarrow.mq-arrow-both': {
+      top: '7.8px',
+      marginTop: '0px',
       minWidth: '1.23em'
     },
     '& .mq-parallelogram': {
@@ -460,7 +483,7 @@ const styles = theme => ({
   inputContainer: {
     minWidth: '500px',
     maxWidth: '900px',
-    minHeight: '40px',
+    minHeight: '30px',
     width: '100%',
     display: 'flex',
     marginTop: theme.spacing.unit,
@@ -475,7 +498,11 @@ const styles = theme => ({
   },
   keyboard: {
     '& *': {
-      fontFamily: 'MJXZERO, MJXTEX-I !important',
+      fontFamily: 'MJXZERO, MJXTEX !important',
+
+      '& .mq-math-mode .mq-sqrt-prefix': {
+        top: '0 !important'
+      },
 
       '& .mq-math-mode .mq-empty': {
         padding: '9px 1px !important'
@@ -507,6 +534,14 @@ const styles = theme => ({
 
       '& .mq-math-mode .mq-paren': {
         verticalAlign: 'middle !important'
+      },
+
+      '& .mq-math-mode .mq-overarrow .mq-overarrow-inner .mq-empty': {
+        padding: '0 !important'
+      },
+
+      '& .mq-math-mode .mq-overline .mq-overline-inner .mq-empty ': {
+        padding: '0 !important'
       }
     }
   }

--- a/packages/math-toolbar/src/editor-and-pad.jsx
+++ b/packages/math-toolbar/src/editor-and-pad.jsx
@@ -295,7 +295,7 @@ const styles = theme => ({
         lineHeight: '1 !important'
       },
       '&:before': {
-        top: '-0.4em',
+        top: '-0.45em',
         left: '-1px'
       },
       '&:after': {
@@ -319,6 +319,10 @@ const styles = theme => ({
         verticalAlign: 'bottom !important',
         top: '0 !important',
         left: '-0.1em !important'
+      },
+
+      '& .mq-math-mode .mq-overarc ': {
+        paddingTop: '0.45em !important'
       },
 
       '& .mq-math-mode sup.mq-nthroot': {

--- a/packages/math-toolbar/src/math-preview.jsx
+++ b/packages/math-toolbar/src/math-preview.jsx
@@ -46,7 +46,68 @@ const mp = theme => ({
       borderRadius: '0px'
     },
     '& *': {
-      fontFamily: 'Roboto, Helvetica, Arial, sans-serif !important'
+      fontFamily: 'MJXZERO, MJXTEX-I !important',
+      // marginTop: '1px',
+      // marginBottom: '-3px',
+
+      '-webkit-font-smoothing': 'antialiased !important'
+    },
+    // '& > .mq-math-mode .mq-root-block': {
+    //   paddingTop: '5px !important'
+    // },
+    '& > .mq-math-mode .mq-sqrt-prefix': {
+      verticalAlign: 'bottom !important',
+      top: '0.2em !important',
+      left: '-0.1em !important'
+    },
+
+    '& > .mq-math-mode sup.mq-nthroot': {
+      fontSize: '70.7% !important',
+      verticalAlign: '0.5em !important',
+      paddingRight: '0.15em'
+    },
+    '& > .mq-math-mode .mq-empty': {
+      padding: '9px 1px !important'
+    },
+    '& > .mq-longdiv-inner': {
+      marginTop: '-1px',
+      marginLeft: '5px !important;',
+
+      '& > .mq-empty': {
+        padding: '0 !important',
+        marginLeft: '0px !important',
+        marginTop: '2px'
+      }
+    },
+    '& > .mq-math-mode .mq-longdiv': {
+      display: 'flex !important'
+    },
+
+    '& > .mq-math-mode .mq-supsub': {
+      fontSize: '70.7% !important'
+    },
+
+    '& > .mq-math-mode .mq-paren': {
+      verticalAlign: 'top !important',
+      padding: '4px 0.1em !important'
+    },
+
+    '& > .mq-math-mode .mq-sqrt-stem': {
+      borderTop: '0.07em solid',
+      marginLeft: '-1.5px',
+      marginTop: '-2px !important',
+      paddingTop: '5px !important'
+    },
+    '& > .mq-supsub ': {
+      fontSize: '70.7%'
+    },
+
+    '& > .mq-math-mode .mq-supsub.mq-sup-only': {
+      verticalAlign: '-0.1em !important',
+
+      '& .mq-sup': {
+        marginBottom: '0px !important'
+      }
     },
     '& .mq-overarrow-inner': {
       paddingTop: '0 !important',

--- a/packages/math-toolbar/src/math-preview.jsx
+++ b/packages/math-toolbar/src/math-preview.jsx
@@ -36,6 +36,10 @@ const mp = theme => ({
     display: 'inline-flex',
     alignItems: 'center',
     position: 'relative',
+    '& *': {
+      fontFamily: 'MJXZERO, MJXTEX-I !important',
+      '-webkit-font-smoothing': 'antialiased !important'
+    },
     '& > .mq-math-mode': {
       border: 'solid 1px lightgrey'
     },
@@ -45,16 +49,10 @@ const mp = theme => ({
       border: 'solid 1px black',
       borderRadius: '0px'
     },
-    '& *': {
-      fontFamily: 'MJXZERO, MJXTEX-I !important',
-      // marginTop: '1px',
-      // marginBottom: '-3px',
-
-      '-webkit-font-smoothing': 'antialiased !important'
+    '& > .mq-math-mode .mq-root-block': {
+      paddingTop: '7px !important',
+      marginTop: '8px'
     },
-    // '& > .mq-math-mode .mq-root-block': {
-    //   paddingTop: '5px !important'
-    // },
     '& > .mq-math-mode .mq-sqrt-prefix': {
       verticalAlign: 'bottom !important',
       top: '0.2em !important',
@@ -65,9 +63,6 @@ const mp = theme => ({
       fontSize: '70.7% !important',
       verticalAlign: '0.5em !important',
       paddingRight: '0.15em'
-    },
-    '& > .mq-math-mode .mq-empty': {
-      padding: '9px 1px !important'
     },
     '& > .mq-longdiv-inner': {
       marginTop: '-1px',
@@ -80,13 +75,21 @@ const mp = theme => ({
       }
     },
     '& > .mq-math-mode .mq-longdiv': {
-      display: 'flex !important'
+      display: 'inline-flex !important'
     },
-
+    '& > .mq-math-mode .mq-longdiv .mq-longdiv-inner .mq-empty': {
+      paddingTop: '6px !important',
+      paddingLeft: '4px !important'
+    },
+    '& > .mq-math-mode .mq-longdiv .mq-longdiv-inner': {
+      marginLeft: '0 !important'
+    },
     '& > .mq-math-mode .mq-supsub': {
       fontSize: '70.7% !important'
     },
-
+    '& > .mq-math-mode .mq-overarrow': {
+      fontFamily: 'Roboto, Helvetica, Arial, sans-serif !important'
+    },
     '& > .mq-math-mode .mq-paren': {
       verticalAlign: 'top !important',
       padding: '4px 0.1em !important'
@@ -123,8 +126,8 @@ const mp = theme => ({
         left: '-1px'
       },
       '&:after': {
-        top: '-2.36em',
-        right: '-1px'
+        top: '-3.15em',
+        right: '-2px'
       },
       '&.mq-empty:after': {
         top: '-0.45em'

--- a/packages/math-toolbar/src/math-preview.jsx
+++ b/packages/math-toolbar/src/math-preview.jsx
@@ -37,7 +37,7 @@ const mp = theme => ({
     alignItems: 'center',
     position: 'relative',
     '& *': {
-      fontFamily: 'MJXZERO, MJXTEX-I !important',
+      fontFamily: 'MJXZERO, MJXTEX !important',
       '-webkit-font-smoothing': 'antialiased !important'
     },
     '& > .mq-math-mode': {
@@ -50,15 +50,22 @@ const mp = theme => ({
       borderRadius: '0px'
     },
     '& > .mq-math-mode .mq-root-block': {
-      paddingTop: '7px !important',
-      marginTop: '8px'
+      paddingTop: '7px !important'
     },
     '& > .mq-math-mode .mq-sqrt-prefix': {
       verticalAlign: 'bottom !important',
-      top: '0.2em !important',
+      top: '0 !important',
       left: '-0.1em !important'
     },
-
+    '& > .mq-math-mode .mq-denominator': {
+      marginTop: '-5px !important',
+      padding: '0.5em 0.1em 0.1em !important'
+    },
+    '& > .mq-math-mode .mq-numerator, .mq-math-mode .mq-over': {
+      padding: '0 0.1em !important',
+      paddingBottom: '0 !important',
+      marginBottom: '4.5px'
+    },
     '& > .mq-math-mode sup.mq-nthroot': {
       fontSize: '70.7% !important',
       verticalAlign: '0.5em !important',
@@ -92,7 +99,7 @@ const mp = theme => ({
     },
     '& > .mq-math-mode .mq-paren': {
       verticalAlign: 'top !important',
-      padding: '4px 0.1em !important'
+      padding: '1px 0.1em !important'
     },
 
     '& > .mq-math-mode .mq-sqrt-stem': {
@@ -116,7 +123,12 @@ const mp = theme => ({
       paddingTop: '0 !important',
       border: 'none !important'
     },
+    '& .mq-editable-field .mq-cursor': {
+      marginTop: '-15px !important'
+    },
     '& .mq-overarrow.mq-arrow-both': {
+      top: '7.5px',
+      marginTop: '0px',
       minWidth: '1.23em',
       '& *': {
         lineHeight: '1 !important'

--- a/packages/math-toolbar/src/math-preview.jsx
+++ b/packages/math-toolbar/src/math-preview.jsx
@@ -40,6 +40,18 @@ const mp = theme => ({
       fontFamily: 'MJXZERO, MJXTEX !important',
       '-webkit-font-smoothing': 'antialiased !important'
     },
+    '& > .mq-math-mode > span > var': {
+      fontFamily: 'MJXZERO, MJXTEX-I !important'
+    },
+    '& > .mq-math-mode span var': {
+      fontFamily: 'MJXZERO, MJXTEX-I !important'
+    },
+    '& > .mq-math-mode .mq-nonSymbola': {
+      fontFamily: 'MJXZERO, MJXTEX-I !important'
+    },
+    '& > .mq-math-mode > span > var.mq-operator-name': {
+      fontFamily: 'MJXZERO, MJXTEX !important'
+    },
     '& > .mq-math-mode': {
       border: 'solid 1px lightgrey'
     },

--- a/packages/math-toolbar/src/math-preview.jsx
+++ b/packages/math-toolbar/src/math-preview.jsx
@@ -52,6 +52,9 @@ const mp = theme => ({
     '& > .mq-math-mode .mq-root-block': {
       paddingTop: '7px !important'
     },
+    '& > .mq-math-mode .mq-overarc ': {
+      paddingTop: '0.45em !important'
+    },
     '& > .mq-math-mode .mq-sqrt-prefix': {
       verticalAlign: 'bottom !important',
       top: '0 !important',


### PR DESCRIPTION
https://illuminate.atlassian.net/browse/PD-1521.

We're not covering everything but we just wanna fix the bad looking math rendering (you can check ticket's comments).

@andreeapescar please do not merge this until @PatriciaRomaniuc & @andreeimiron will test this PR.

Thanks!