### PR TITLE
feat: UI improvements and bit of cleanup for PD-23-updated

### DIFF
--- a/packages/editable-html/src/plugins/media/index.jsx
+++ b/packages/editable-html/src/plugins/media/index.jsx
@@ -165,7 +165,7 @@ export default function MediaPlugin(type, opts) {
               <audio controls="controls">
                 <source type="audio/mp3" src={src} />
               </audio>
-              <MediaToolbar onEdit={handleEdit} onRemove={handleDelete} />
+              <MediaToolbar hideEdit onRemove={handleDelete} />
             </MediaWrapper>
           );
         }

--- a/packages/editable-html/src/plugins/media/media-toolbar.jsx
+++ b/packages/editable-html/src/plugins/media/media-toolbar.jsx
@@ -31,17 +31,20 @@ class MediaToolbar extends React.Component {
   static propTypes = {
     classes: PropTypes.object,
     onEdit: PropTypes.func,
+    hideEdit: PropTypes.bool,
     onRemove: PropTypes.func
   };
 
   render() {
-    const { classes, onEdit, onRemove } = this.props;
+    const { classes, hideEdit, onEdit, onRemove } = this.props;
 
     return (
       <span className={classes.root}>
-        <span className={classes.editContainer} onClick={onEdit}>
-          Edit Settings
-        </span>
+        {hideEdit ? null : (
+          <span className={classes.editContainer} onClick={onEdit}>
+            Edit Settings
+          </span>
+        )}
         <span className={classes.removeContainer} onClick={onRemove}>
           Remove
         </span>


### PR DESCRIPTION
https://illuminate.atlassian.net/browse/PD-23

Please note that a "Loading..." will be shown until the file is uploaded by the client. Not 100% it is good to show it - it will be sticky in testing environments - maybe we can check with George. 

For now we hide "Edit Settings" for uploaded sound in editable-html and show "Remove" option only. This can be a nice task if it's wanted - the developer will have to make some changes in the code to have a consistent logic though (url vs uploaded sound). 

Progress can be implemented as well. 