### PR TITLE
fix(config-ui): make sure that the bounds for the ConfigLayout are calculated before rendering the elements on iPads PD-2462 PD-2463 

### DIFF
--- a/packages/config-ui/src/layout/__tests__/__snapshots__/config.layout.test.jsx.snap
+++ b/packages/config-ui/src/layout/__tests__/__snapshots__/config.layout.test.jsx.snap
@@ -1,19 +1,77 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`layout - snapshot renders correctly with a side panel 1`] = `
-<Measure
-  bounds={true}
-  onResize={[Function]}
+<MeasuredConfigLayout
+  contentRect={
+    Object {
+      "bounds": Object {},
+      "client": Object {},
+      "entry": Object {},
+      "margin": Object {},
+      "offset": Object {},
+      "scroll": Object {},
+    }
+  }
+  hideSettings={false}
+  measure={[Function]}
+  measureRef={[Function]}
+  settings={
+    <div>
+      <div>
+        Foo
+      </div>
+      <div>
+        Bar
+      </div>
+    </div>
+  }
+  sidePanelMinWidth={950}
 >
-  <Component />
-</Measure>
+  <div>
+    <div>
+      Foo
+    </div>
+    <div>
+      Bar
+    </div>
+  </div>
+</MeasuredConfigLayout>
 `;
 
 exports[`layout - snapshot renders correctly without a side panel 1`] = `
-<Measure
-  bounds={true}
-  onResize={[Function]}
+<MeasuredConfigLayout
+  contentRect={
+    Object {
+      "bounds": Object {},
+      "client": Object {},
+      "entry": Object {},
+      "margin": Object {},
+      "offset": Object {},
+      "scroll": Object {},
+    }
+  }
+  hideSettings={false}
+  measure={[Function]}
+  measureRef={[Function]}
+  settings={
+    <div>
+      <div>
+        Foo
+      </div>
+      <div>
+        Bar
+      </div>
+    </div>
+  }
+  sidePanelMinWidth={950}
 >
-  <Component />
-</Measure>
+  <div>
+    <div>
+      Foo
+    </div>
+    <div>
+      Bar
+    </div>
+  </div>
+</MeasuredConfigLayout>
 `;

--- a/packages/config-ui/src/layout/config-layout.jsx
+++ b/packages/config-ui/src/layout/config-layout.jsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import Measure from 'react-measure';
+import { withContentRect } from 'react-measure';
 import PropTypes from 'prop-types';
 import LayoutContents from './layout-contents';
 import SettingsBox from './settings-box';
 
-class ConfigLayout extends React.Component {
+class MeasuredConfigLayout extends React.Component {
   static propTypes = {
     children: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.element), PropTypes.element]),
     className: PropTypes.string,
@@ -54,5 +55,7 @@ class ConfigLayout extends React.Component {
     );
   }
 }
+
+const ConfigLayout = withContentRect('bounds')(MeasuredConfigLayout);
 
 export default ConfigLayout;


### PR DESCRIPTION
https://illuminate.atlassian.net/browse/PD-2462
https://illuminate.atlassian.net/browse/PD-2463