### PR TITLE
feat(config-ui): added default classnames for main components

### DIFF
--- a/packages/config-ui/src/layout/config-layout.jsx
+++ b/packages/config-ui/src/layout/config-layout.jsx
@@ -40,11 +40,12 @@ class MeasuredConfigLayout extends React.Component {
           const { children, settings, hideSettings } = this.props;
           const { layoutMode } = this.state;
 
-          const settingsPanel = layoutMode === 'inline' ? <SettingsBox>{settings}</SettingsBox> : settings;
+          const settingsPanel =
+            layoutMode === 'inline' ? <SettingsBox className="settings-box">{settings}</SettingsBox> : settings;
           const secondaryContent = hideSettings ? null : settingsPanel;
 
           return (
-            <div ref={measureRef}>
+            <div ref={measureRef} className="main-container">
               <LayoutContents mode={layoutMode} secondary={secondaryContent}>
                 {children}
               </LayoutContents>

--- a/packages/config-ui/src/layout/layout-contents.jsx
+++ b/packages/config-ui/src/layout/layout-contents.jsx
@@ -64,19 +64,29 @@ class RawLayoutContents extends React.Component {
       <div className={classes.container}>
         {mode === 'inline' && (
           <div className={classnames(classes.flow, classes.contentContainer)}>
-            <div className={classes.configContainer}>{children}</div>
-            {hasSettingsPanel && <div className={classes.settingsContainer}>{secondary}</div>}
+            <div className={classnames(classes.configContainer, 'design-container')}>{children}</div>
+            {hasSettingsPanel && (
+              <div className={classnames(classes.settingsContainer, 'settings-container')}>{secondary}</div>
+            )}
           </div>
         )}
 
         {mode === 'tabbed' && hasSettingsPanel && (
           <Tabs onChange={this.onTabsChange} contentClassName={classes.contentContainer} indicatorColor="primary">
-            <div title="Design">{children}</div>
-            <div title="Settings">{secondary}</div>
+            <div title="Design" className="design-container">
+              {children}
+            </div>
+            <div title="Settings" className="settings-container">
+              {secondary}
+            </div>
           </Tabs>
         )}
 
-        {mode === 'tabbed' && !hasSettingsPanel && <div className={classes.contentContainer}>{children}</div>}
+        {mode === 'tabbed' && !hasSettingsPanel && (
+          <div className={classes.contentContainer} className="design-container">
+            {children}
+          </div>
+        )}
       </div>
     );
   }


### PR DESCRIPTION
Added the following classnames:
**main-container** - for the main wrapper
**design-container** - for the design wrapper
**settings-container** - for the settings wrapper
**settings-box** - for the settings wrapper child (available when design and settings containers are displayed at the same time on the screen)