### PR TITLE
feat: expanded translator by exposing languageOptions PD-2795

### DIFF
--- a/packages/demo/pages/translator/index.js
+++ b/packages/demo/pages/translator/index.js
@@ -2,15 +2,17 @@ import React from "react";
 import withRoot from "../../src/withRoot";
 import { withStyles } from "@material-ui/core";
 
-import translator from "../../../translator";
+import Translator from "../../../translator";
 import MenuItem from "@material-ui/core/MenuItem";
 import Select from "@material-ui/core/Select";
+
+const { translator, languageOptions } = Translator;
 
 class Demo extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      language: "es"
+      language: languageOptions[0].value,
     };
   }
 
@@ -31,9 +33,9 @@ class Demo extends React.Component {
             id: 'markup',
           }}
         >
-          {['en', 'es', 'en_US', 'es_ES', 'es_MX'].map((i) => (
-            <MenuItem key={i.label} value={i}>
-              {i}
+          {languageOptions.map((i) => (
+            <MenuItem key={i.label} value={i.value}>
+              {i.label}
             </MenuItem>
           ))}
         </Select>

--- a/packages/translator/src/index.js
+++ b/packages/translator/src/index.js
@@ -15,25 +15,31 @@ i18next.init(
 );
 
 export default {
-  ...i18next,
-  t: (key, options) => {
-    const { lng } = options;
+  translator: {
+    ...i18next,
+    t: (key, options) => {
+      const { lng } = options;
 
-    switch (lng) {
-      // these keys don't work with plurals, don't know why, so I added a workaround to convert them to the correct lng
-      case "en_US":
-      case "en-US":
-        options.lng = "en";
-        break;
-      case "es_ES":
-      case "es-ES":
-      case "es_MX":
-      case "es-MX":
-        options.lng = "es";
-        break;
-      default:
-        break;
-    }
-    return i18next.t(key, { lng, ...options });
-  }
+      switch (lng) {
+        // these keys don't work with plurals, don't know why, so I added a workaround to convert them to the correct lng
+        case "en_US":
+        case "en-US":
+          options.lng = "en";
+          break;
+        case "es_ES":
+        case "es-ES":
+        case "es_MX":
+        case "es-MX":
+          options.lng = "es";
+          break;
+        default:
+          break;
+      }
+      return i18next.t(key, { lng, ...options });
+    },
+  },
+  languageOptions: [
+    { value: "en_US", label: "English (US)" },
+    { value: "es_ES", label: "Spanish" }
+  ],
 };


### PR DESCRIPTION
BREAKING CHANGE: The translator is now inside the returned object, not the object itself.