### PR TITLE
(drag-in-the-blank): add preview on drag items for touch backend PD-2992

### DIFF
--- a/packages/drag/package.json
+++ b/packages/drag/package.json
@@ -11,7 +11,7 @@
     "react-dnd": "^14.0.5",
     "react-dnd-html5-backend": "^14.0.2",
     "react-dnd-multi-backend": "^6.0.2",
-    "react-dnd-touch-backend": "^14.1.0"
+    "react-dnd-touch-backend": "^12.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/drag/src/with-drag-context.js
+++ b/packages/drag/src/with-drag-context.js
@@ -1,7 +1,26 @@
 import React from 'react';
-import MultiBackend from 'react-dnd-multi-backend';
+import MultiBackend, { TouchTransition } from 'react-dnd-multi-backend';
 import { DndProvider } from 'react-dnd';
-import HTML5toTouch from 'react-dnd-multi-backend/dist/cjs/HTML5toTouch';
+import HTML5Backend from 'react-dnd-html5-backend';
+import TouchBackend from 'react-dnd-touch-backend';
+
+console.log('HTML5Backend:', HTML5Backend);
+console.log('TouchBackend:', TouchBackend);
+
+const HTML5toTouch = {
+  backends: [
+    {
+      backend: HTML5Backend,
+      transition: TouchTransition,
+    },
+    {
+      backend: TouchBackend,
+      options: { enableMouseEvents: true },
+      preview: true,
+      transition: TouchTransition,
+    },
+  ],
+};
 
 export default (Component) => (props) => (
   <DndProvider backend={MultiBackend} options={HTML5toTouch} context={window}>

--- a/packages/drag/src/with-drag-context.js
+++ b/packages/drag/src/with-drag-context.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import MultiBackend, { TouchTransition } from 'react-dnd-multi-backend';
+import MultiBackend, { TouchTransition, Preview } from 'react-dnd-multi-backend';
 import { DndProvider } from 'react-dnd';
 import { TouchBackend } from 'react-dnd-touch-backend';
 import { HTML5Backend } from 'react-dnd-html5-backend';
@@ -12,15 +12,20 @@ const HTML5toTouch = {
     {
       backend: TouchBackend,
       options: { enableMouseEvents: true },
-      // preview: true,
+      preview: true,
       transition: TouchTransition,
       skipDispatchOnTransition: true,
     },
   ],
 };
 
+const PreviewComponent = ({ itemType, item, style }) => (
+  <div style={{ ...style }} dangerouslySetInnerHTML={{ __html: item.choice.value }} />
+);
+
 export default (Component) => (props) => (
   <DndProvider backend={MultiBackend} options={HTML5toTouch} context={window}>
     <Component {...props} />
+    <Preview generator={PreviewComponent} {...props} />
   </DndProvider>
 );

--- a/packages/drag/src/with-drag-context.js
+++ b/packages/drag/src/with-drag-context.js
@@ -19,9 +19,32 @@ const HTML5toTouch = {
   ],
 };
 
-const PreviewComponent = ({ itemType, item, style }) => (
-  <div style={{ ...style }} dangerouslySetInnerHTML={{ __html: item.choice.value }} />
-);
+const PreviewComponent = ({ itemType, item, style }) => {
+  console.log('itemType:', itemType);
+  console.log('style:', style);
+  // Default style
+  let customStyle = { ...style };
+
+  // Additional style if itemType is 'blank'
+  if (itemType === 'MaskBlank') {
+    customStyle = {
+      ...customStyle,
+      border: '1px solid black',
+      color: 'black',
+      minWidth: '90px',
+      minHeight: '32px',
+      height: 'auto',
+      maxWidth: '374px',
+      display: 'flex',
+      padding: '4px',
+      alignItems: 'center',
+      justifyContent: 'center',
+      borderRadius: '16px',
+    };
+  }
+
+  return <div style={customStyle} dangerouslySetInnerHTML={{ __html: item.choice.value }} />;
+};
 
 export default (Component) => (props) => (
   <DndProvider backend={MultiBackend} options={HTML5toTouch} context={window}>

--- a/packages/drag/src/with-drag-context.js
+++ b/packages/drag/src/with-drag-context.js
@@ -1,66 +1,66 @@
 import React, { useEffect, useRef } from 'react';
-import MultiBackend, { TouchTransition, Preview } from 'react-dnd-multi-backend';
+import MultiBackend, { TouchTransition, usePreview } from 'react-dnd-multi-backend';
 import { PreviewPrompt } from '@pie-lib/render-ui';
 import { DndProvider } from 'react-dnd';
 import { TouchBackend } from 'react-dnd-touch-backend';
 import { HTML5Backend } from 'react-dnd-html5-backend';
 import { renderMath } from '@pie-lib/math-rendering';
 
-const HTML5toTouch = {
-  backends: [
-    {
-      backend: HTML5Backend,
-    },
-    {
-      backend: TouchBackend,
-      options: { enableMouseEvents: true },
-      preview: true,
-      transition: TouchTransition,
-      skipDispatchOnTransition: true,
-    },
-  ],
+const backends = [
+  { backend: HTML5Backend },
+  {
+    backend: TouchBackend,
+    options: { enableMouseEvents: true },
+    preview: true,
+    transition: TouchTransition,
+    skipDispatchOnTransition: true,
+  },
+];
+
+const MaskBlankStyle = {
+  border: '1px solid black',
+  color: 'black',
+  minWidth: '90px',
+  minHeight: '32px',
+  height: 'auto',
+  maxWidth: '374px',
+  display: 'flex',
+  padding: '4px',
+  alignItems: 'center',
+  justifyContent: 'center',
+  borderRadius: '16px',
 };
 
-const PreviewComponent = ({ itemType, item, style }) => {
-  // Default style
-  let customStyle = { ...style };
+const PreviewComponent = () => {
+  let root = useRef(null);
+  const preview = usePreview();
 
-  // Additional style if itemType is 'blank'
-  if (itemType === 'MaskBlank') {
-    customStyle = {
-      ...customStyle,
-      border: '1px solid black',
-      color: 'black',
-      minWidth: '90px',
-      minHeight: '32px',
-      height: 'auto',
-      maxWidth: '374px',
-      display: 'flex',
-      padding: '4px',
-      alignItems: 'center',
-      justifyContent: 'center',
-      borderRadius: '16px',
-    };
+  useEffect(() => {
+    if (preview?.display && root.current) {
+      renderMath(root.current);
+    }
+  }, [preview?.display, preview?.item?.choice?.value]);
+
+  if (!preview.display) {
+    return null;
   }
 
+  const { itemType, item, style } = preview;
+  const customStyle = {
+    ...style,
+    ...(itemType === 'MaskBlank' ? MaskBlankStyle : {}),
+  };
+
   return (
-    <div style={customStyle}>
+    <div ref={root} style={customStyle}>
       <PreviewPrompt className="label" prompt={item.choice.value} tagName="span" />
     </div>
   );
 };
 
-export default (Component) => (props) => {
-  const root = useRef(null);
-
-  useEffect(() => {
-    renderMath(root);
-  }, []);
-
-  return (
-    <DndProvider backend={MultiBackend} options={HTML5toTouch} context={window}>
-      <Component {...props} />
-      <Preview ref={root} generator={PreviewComponent} {...props} />
-    </DndProvider>
-  );
-};
+export default (Component) => (props) => (
+  <DndProvider backend={MultiBackend} options={{ backends }} context={window}>
+    <Component {...props} />
+    <PreviewComponent />
+  </DndProvider>
+);

--- a/packages/drag/src/with-drag-context.js
+++ b/packages/drag/src/with-drag-context.js
@@ -1,23 +1,20 @@
 import React from 'react';
 import MultiBackend, { TouchTransition } from 'react-dnd-multi-backend';
 import { DndProvider } from 'react-dnd';
-import HTML5Backend from 'react-dnd-html5-backend';
-import TouchBackend from 'react-dnd-touch-backend';
-
-console.log('HTML5Backend:', HTML5Backend);
-console.log('TouchBackend:', TouchBackend);
+import { TouchBackend } from 'react-dnd-touch-backend';
+import { HTML5Backend } from 'react-dnd-html5-backend';
 
 const HTML5toTouch = {
   backends: [
     {
       backend: HTML5Backend,
-      transition: TouchTransition,
     },
     {
       backend: TouchBackend,
       options: { enableMouseEvents: true },
-      preview: true,
+      // preview: true,
       transition: TouchTransition,
+      skipDispatchOnTransition: true,
     },
   ],
 };

--- a/packages/drag/src/with-drag-context.js
+++ b/packages/drag/src/with-drag-context.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import MultiBackend, { TouchTransition, Preview } from 'react-dnd-multi-backend';
+import { PreviewPrompt } from '@pie-lib/render-ui';
 import { DndProvider } from 'react-dnd';
 import { TouchBackend } from 'react-dnd-touch-backend';
 import { HTML5Backend } from 'react-dnd-html5-backend';
@@ -42,8 +43,13 @@ const PreviewComponent = ({ itemType, item, style }) => {
       borderRadius: '16px',
     };
   }
+  console.log(item.choice.value, 'value');
 
-  return <div style={customStyle} dangerouslySetInnerHTML={{ __html: item.choice.value }} />;
+  return (
+    <div style={customStyle}>
+      <PreviewPrompt className="label" prompt={item.choice.value} tagName="span" />
+    </div>
+  );
 };
 
 export default (Component) => (props) => (

--- a/packages/drag/src/with-drag-context.js
+++ b/packages/drag/src/with-drag-context.js
@@ -1,9 +1,10 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import MultiBackend, { TouchTransition, Preview } from 'react-dnd-multi-backend';
 import { PreviewPrompt } from '@pie-lib/render-ui';
 import { DndProvider } from 'react-dnd';
 import { TouchBackend } from 'react-dnd-touch-backend';
 import { HTML5Backend } from 'react-dnd-html5-backend';
+import { renderMath } from '@pie-lib/math-rendering';
 
 const HTML5toTouch = {
   backends: [
@@ -21,8 +22,6 @@ const HTML5toTouch = {
 };
 
 const PreviewComponent = ({ itemType, item, style }) => {
-  console.log('itemType:', itemType);
-  console.log('style:', style);
   // Default style
   let customStyle = { ...style };
 
@@ -43,7 +42,6 @@ const PreviewComponent = ({ itemType, item, style }) => {
       borderRadius: '16px',
     };
   }
-  console.log(item.choice.value, 'value');
 
   return (
     <div style={customStyle}>
@@ -52,9 +50,17 @@ const PreviewComponent = ({ itemType, item, style }) => {
   );
 };
 
-export default (Component) => (props) => (
-  <DndProvider backend={MultiBackend} options={HTML5toTouch} context={window}>
-    <Component {...props} />
-    <Preview generator={PreviewComponent} {...props} />
-  </DndProvider>
-);
+export default (Component) => (props) => {
+  const root = useRef(null);
+
+  useEffect(() => {
+    renderMath(root);
+  }, []);
+
+  return (
+    <DndProvider backend={MultiBackend} options={HTML5toTouch} context={window}>
+      <Component {...props} />
+      <Preview ref={root} generator={PreviewComponent} {...props} />
+    </DndProvider>
+  );
+};

--- a/packages/mask-markup/src/components/blank.jsx
+++ b/packages/mask-markup/src/components/blank.jsx
@@ -226,6 +226,7 @@ const tileSource = {
       choice: props.choice,
       instanceId: props.instanceId,
       fromChoice: true,
+      root: 'test',
     };
   },
   endDrag(props, monitor) {

--- a/packages/mask-markup/src/components/blank.jsx
+++ b/packages/mask-markup/src/components/blank.jsx
@@ -31,7 +31,6 @@ const useStyles = withStyles(() => ({
   },
   chipLabel: {
     whiteSpace: 'pre-wrap',
-    touchAction: 'none',
     // Added for touch devices, for image content.
     // This will prevent the context menu from appearing and not allowing other interactions with the image.
     // If interactions with the image in the token will be requested we should handle only the context Menu.
@@ -226,7 +225,6 @@ const tileSource = {
       choice: props.choice,
       instanceId: props.instanceId,
       fromChoice: true,
-      root: 'test',
     };
   },
   endDrag(props, monitor) {

--- a/packages/mask-markup/src/components/blank.jsx
+++ b/packages/mask-markup/src/components/blank.jsx
@@ -31,6 +31,7 @@ const useStyles = withStyles(() => ({
   },
   chipLabel: {
     whiteSpace: 'pre-wrap',
+    touchAction: 'none',
     // Added for touch devices, for image content.
     // This will prevent the context menu from appearing and not allowing other interactions with the image.
     // If interactions with the image in the token will be requested we should handle only the context Menu.

--- a/yarn.lock
+++ b/yarn.lock
@@ -6212,6 +6212,15 @@ discontinuous-range@1.0.0:
   resolved "https://registry.yarnpkg.com/discontinuous-range/-/discontinuous-range-1.0.0.tgz#e38331f0844bba49b9a9cb71c771585aab1bc65a"
   integrity sha1-44Mx8IRLukm5qctxx3FYWqsbxlo=
 
+dnd-core@12.0.0:
+  version "12.0.0"
+  resolved "https://registry.yarnpkg.com/dnd-core/-/dnd-core-12.0.0.tgz#b5b243121538279782a8ca35c4e55234a621f1ed"
+  integrity sha512-7GQTkQfNmmdFBN85hN0aHKXeP6Vf4yFUZQBT02+yHKbR82C80N504onI4Av5ZKm2goY1ppQr3wdDp5pa5tlaYA==
+  dependencies:
+    "@react-dnd/asap" "^4.0.0"
+    "@react-dnd/invariant" "^2.0.0"
+    redux "^4.0.5"
+
 dnd-core@14.0.1:
   version "14.0.1"
   resolved "https://registry.yarnpkg.com/dnd-core/-/dnd-core-14.0.1.tgz#76d000e41c494983210fb20a48b835f81a203c2e"
@@ -13433,13 +13442,13 @@ react-dnd-preview@^6.0.2:
   dependencies:
     prop-types "^15.7.2"
 
-react-dnd-touch-backend@^14.1.0:
-  version "14.1.1"
-  resolved "https://registry.yarnpkg.com/react-dnd-touch-backend/-/react-dnd-touch-backend-14.1.1.tgz#d8875ef1cf8dcbf1741a4e03dd5b147c4fbda5e4"
-  integrity sha512-ITmfzn3fJrkUBiVLO6aJZcnu7T8C+GfwZitFryGsXKn5wYcUv+oQBeh9FYcMychmVbDdeUCfvEtTk9O+DKmAaw==
+react-dnd-touch-backend@^12.0.0:
+  version "12.0.0"
+  resolved "https://registry.yarnpkg.com/react-dnd-touch-backend/-/react-dnd-touch-backend-12.0.0.tgz#47c93044ce424dbeeb09b2da6dc68b1ff04ee6cb"
+  integrity sha512-YcXb0S6/87KIGGJQEGvc+dhgVIoPikM23VJs10y9AKrezao9bIXiMtd5+Sg4dDAcUduptvvbohCTpkm0E6mrtg==
   dependencies:
     "@react-dnd/invariant" "^2.0.0"
-    dnd-core "14.0.1"
+    dnd-core "12.0.0"
 
 react-dnd@^11.1.3:
   version "11.1.3"
@@ -13829,6 +13838,13 @@ redux@^4.0.0, redux@^4.0.1, redux@^4.0.4, redux@^4.1.1:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/redux/-/redux-4.2.0.tgz#46f10d6e29b6666df758780437651eeb2b969f13"
   integrity sha512-oSBmcKKIuIR4ME29/AeNUnl5L+hvBq7OaJWzaptTQJAntaPvxIJqfnjbaEiCzzaIz+XmVILfqAM3Ob0aXLPfjA==
+  dependencies:
+    "@babel/runtime" "^7.9.2"
+
+redux@^4.0.5:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/redux/-/redux-4.2.1.tgz#c08f4306826c49b5e9dc901dee0452ea8fce6197"
+  integrity sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==
   dependencies:
     "@babel/runtime" "^7.9.2"
 


### PR DESCRIPTION
https://illuminate.atlassian.net/browse/PD-2992

In version 2.2.1 of @pie-lib/drag, I introduced 'react-dnd-multi-backend'. However, this inadvertently led to an 'Invisible drag' issue on touch devices, due to the absence of a preview for the dragged element. To address this, I've incorporated a preview component in this Pull Request that aligns with the TouchBackend, effectively emulating the existing preview functionality of the HTML5Backend. This update aims to provide a consistent and intuitive drag-and-drop experience across various devices and interaction modes.

The drag functionality we currently have utilizes different 'choices' or 'components' for each element, necessitating unique styling for each element. This Pull Request, however, specifically addresses the styling for 'drag-in-the-blank' items only. 