### PR TITLE
fix(charting): set labelWidth to prevent outline from intersecting InputLabel for the ChartType menu PD-3166

### DIFF
--- a/packages/charting/src/chart-type.js
+++ b/packages/charting/src/chart-type.js
@@ -20,7 +20,7 @@ const ChartType = withStyles(() => ({
         {chartTypeLabel}
       </InputLabel>
 
-      <Select value={value} onChange={onChange} labelWidth={0} input={<OutlinedInput name="type" id="type-helper" />}>
+      <Select value={value} onChange={onChange} labelWidth={75} input={<OutlinedInput name="type" id="type-helper" />}>
         {availableChartTypes?.histogram && <MenuItem value={'histogram'}>{availableChartTypes.histogram}</MenuItem>}
         {availableChartTypes?.bar && <MenuItem value={'bar'}>{availableChartTypes.bar}</MenuItem>}
         {availableChartTypes?.lineDot && <MenuItem value={'lineDot'}>{availableChartTypes.lineDot}</MenuItem>}


### PR DESCRIPTION
https://illuminate.atlassian.net/browse/PD-3166