### PR TITLE
fix(charting): use red boxes only and for all duplicated category names, reorder CSS selectors to resolve styling conflicts, refine error message display to prevent overlapping with other elements and other messages PD-3121

### DIFF
--- a/packages/charting/src/axes.jsx
+++ b/packages/charting/src/axes.jsx
@@ -9,7 +9,6 @@ import { bandKey, getTickValues, getRotateAngle } from './utils';
 import MarkLabel from './mark-label';
 import Checkbox from '@material-ui/core/Checkbox';
 
-const displayedErrors = new Set();
 export class TickComponent extends React.Component {
   static propTypes = {
     defineChart: PropTypes.bool,
@@ -148,16 +147,6 @@ export class TickComponent extends React.Component {
 
     const longestLabel = (longestCategory && longestCategory.label) || '';
 
-    let renderError = null;
-    if (error && error[index] && !displayedErrors.has(error[index])) {
-      displayedErrors.add(error[index]);
-      renderError = (
-        <text className={classes.error} x={x} y={y + 23} height={4}>
-          {error[index]}
-        </text>
-      );
-    }
-
     return (
       <g>
         <foreignObject
@@ -193,17 +182,16 @@ export class TickComponent extends React.Component {
             barWidth={barWidth}
             rotate={rotate}
             correctness={correctness}
-            error={error && error[index]}
+            error={error && (error[index] || error[index] == '')}
           />
         </foreignObject>
-        {/* 
+
         {error && error[index] && (
           <text className={classes.error} x={x} y={y + 23} height={4}>
             {error[index]}
           </text>
-        )} */}
+        )}
 
-        {renderError}
         {deletable && !correctness && (
           <line x1={x} y1={0} x2={x} y2={y + 4 + top} className={classes.dottedLine} strokeDasharray="4 2" />
         )}

--- a/packages/charting/src/axes.jsx
+++ b/packages/charting/src/axes.jsx
@@ -146,6 +146,7 @@ export class TickComponent extends React.Component {
     });
 
     const longestLabel = (longestCategory && longestCategory.label) || '';
+    const distinctMessages = error ? [...new Set(Object.values(error))].join(' ') : '';
 
     return (
       <g>
@@ -186,9 +187,9 @@ export class TickComponent extends React.Component {
           />
         </foreignObject>
 
-        {error && error[index] && (
-          <text className={classes.error} x={x} y={y + 23} height={4}>
-            {error[index]}
+        {error && index === 0 && (
+          <text className={classes.error} y={y + 23} height={6} textAnchor="start">
+            {distinctMessages}
           </text>
         )}
 

--- a/packages/charting/src/axes.jsx
+++ b/packages/charting/src/axes.jsx
@@ -183,7 +183,7 @@ export class TickComponent extends React.Component {
             barWidth={barWidth}
             rotate={rotate}
             correctness={correctness}
-            error={error && (error[index] || error[index] == '')}
+            error={error && error[index]}
           />
         </foreignObject>
 

--- a/packages/charting/src/axes.jsx
+++ b/packages/charting/src/axes.jsx
@@ -9,6 +9,7 @@ import { bandKey, getTickValues, getRotateAngle } from './utils';
 import MarkLabel from './mark-label';
 import Checkbox from '@material-ui/core/Checkbox';
 
+const displayedErrors = new Set();
 export class TickComponent extends React.Component {
   static propTypes = {
     defineChart: PropTypes.bool,
@@ -147,6 +148,16 @@ export class TickComponent extends React.Component {
 
     const longestLabel = (longestCategory && longestCategory.label) || '';
 
+    let renderError = null;
+    if (error && error[index] && !displayedErrors.has(error[index])) {
+      displayedErrors.add(error[index]);
+      renderError = (
+        <text className={classes.error} x={x} y={y + 23} height={4}>
+          {error[index]}
+        </text>
+      );
+    }
+
     return (
       <g>
         <foreignObject
@@ -182,16 +193,17 @@ export class TickComponent extends React.Component {
             barWidth={barWidth}
             rotate={rotate}
             correctness={correctness}
-            error={error}
+            error={error && error[index]}
           />
         </foreignObject>
-
+        {/* 
         {error && error[index] && (
           <text className={classes.error} x={x} y={y + 23} height={4}>
             {error[index]}
           </text>
-        )}
+        )} */}
 
+        {renderError}
         {deletable && !correctness && (
           <line x1={x} y1={0} x2={x} y2={y + 4 + top} className={classes.dottedLine} strokeDasharray="4 2" />
         )}

--- a/packages/charting/src/mark-label.jsx
+++ b/packages/charting/src/mark-label.jsx
@@ -15,13 +15,13 @@ const styles = (theme) => ({
     fontSize: theme.typography.fontSize,
     border: 'none',
     color: color.primaryDark(),
-    '&.error': { border: `2px solid ${theme.palette.error.main}` },
     '&.correct': correct('color'),
     '&.incorrect': incorrect('color'),
     '&.disabled': {
       ...disabled('color'),
       backgroundColor: 'transparent !important',
     },
+    '&.error': { border: `2px solid ${theme.palette.error.main}` },
   },
   mathInput: {
     pointerEvents: 'auto',

--- a/packages/plot/src/label.jsx
+++ b/packages/plot/src/label.jsx
@@ -40,7 +40,7 @@ const LabelComponent = (props) => {
       chartValue ||
       (isChartLeftLabel && `${graphHeight - 70}px`) ||
       (side === 'left' && `${graphHeight - 8}px`) ||
-      (isChartBottomLabel && `${graphHeight - 40}px`) ||
+      (isChartBottomLabel && `${graphHeight - 30}px`) ||
       (side === 'bottom' && `${graphHeight - 90}px`) ||
       0,
     left:


### PR DESCRIPTION
https://illuminate.atlassian.net/jira/software/c/projects/PD/issues/PD-3121?filter=myopenissues