### PR TITLE
build: temporary disable pslb to prevent production crashes until we …

### DIFF
--- a/scripts/build
+++ b/scripts/build
@@ -15,19 +15,19 @@ class LibCommands extends Commands {
     return this.staticToNow(resolve(demoDir, 'out'), alias);
   }
 
-  sharedBuild() {
-    if (args.next) {
-      return Promise.resolve();
-    } else {
-      return this.runCmd(
-        `yarn pslb --config pslb/pslb.config.js --publishLibs --token ${args.token} --cleanLibs --logLevel debug`
-      );
-    }
-  }
-
-  build() {
-    return super.build().then(() => this.sharedBuild());
-  }
+  // sharedBuild() {
+  //   if (args.next) {
+  //     return Promise.resolve();
+  //   } else {
+  //     return this.runCmd(
+  //       `yarn pslb --config pslb/pslb.config.js --publishLibs --token ${args.token} --cleanLibs --logLevel debug`
+  //     );
+  //   }
+  // }
+  //
+  // build() {
+  //   return super.build().then(() => this.sharedBuild());
+  // }
 }
 
 const cmds = new LibCommands(resolve(__dirname, '..'), args);


### PR DESCRIPTION
…figure out why it was taking latest versions