### PR TITLE
fix(editable-html): Add preview dialog for HTML edits and improve exit workflow PD-2765

### DIFF
--- a/packages/pie-toolbox/src/code/charting/__tests__/__snapshots__/axes.test.jsx.snap
+++ b/packages/pie-toolbox/src/code/charting/__tests__/__snapshots__/axes.test.jsx.snap
@@ -535,6 +535,8 @@ exports[`TickComponent snapshot1 renders 1`] = `
     y={NaN}
   >
     <AlertDialog
+      onCloseText="CANCEL"
+      onConfirmText="OK"
       open={false}
     />
   </foreignObject>

--- a/packages/pie-toolbox/src/code/charting/__tests__/__snapshots__/chart.test.jsx.snap
+++ b/packages/pie-toolbox/src/code/charting/__tests__/__snapshots__/chart.test.jsx.snap
@@ -195,6 +195,8 @@ exports[`ChartAxes snapshot renders 1`] = `
     </g>
   </WithStyles(Root)>
   <AlertDialog
+    onCloseText="CANCEL"
+    onConfirmText="OK"
     open={false}
   />
 </div>
@@ -395,6 +397,8 @@ exports[`ChartAxes snapshot renders if size is not defined 1`] = `
     </g>
   </WithStyles(Root)>
   <AlertDialog
+    onCloseText="CANCEL"
+    onConfirmText="OK"
     open={false}
   />
 </div>
@@ -599,6 +603,8 @@ exports[`ChartAxes snapshot renders without chartType property 1`] = `
     </g>
   </WithStyles(Root)>
   <AlertDialog
+    onCloseText="CANCEL"
+    onConfirmText="OK"
     open={false}
   />
 </div>

--- a/packages/pie-toolbox/src/code/config-ui/alert-dialog.jsx
+++ b/packages/pie-toolbox/src/code/config-ui/alert-dialog.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Button, Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle } from '@material-ui/core';
 
-const AlertDialog = ({ text, title, onClose, onConfirm, open }) => (
+const AlertDialog = ({ text, title, onClose, onConfirm, open, onCloseText, onConfirmText }) => (
   <Dialog open={open} onClose={onClose}>
     {title && <DialogTitle>{title}</DialogTitle>}
     {text && (
@@ -13,24 +13,31 @@ const AlertDialog = ({ text, title, onClose, onConfirm, open }) => (
     <DialogActions>
       {onClose && (
         <Button onClick={onClose} color="primary">
-          CANCEL
+          {onCloseText}
         </Button>
       )}
       {onConfirm && (
         <Button autoFocus onClick={onConfirm} color="primary">
-          OK
+          {onConfirmText}
         </Button>
       )}
     </DialogActions>
   </Dialog>
 );
 
+AlertDialog.defaultProps = {
+  onCloseText: 'CANCEL',
+  onConfirmText: 'OK',
+};
+
 AlertDialog.propTypes = {
-  text: PropTypes.string,
+  text: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
   title: PropTypes.string,
   onClose: PropTypes.func,
   onConfirm: PropTypes.func,
   open: PropTypes.bool,
+  onConfirmText: PropTypes.string,
+  onCloseText: PropTypes.string,
 };
 
 export default AlertDialog;

--- a/packages/pie-toolbox/src/code/editable-html/plugins/html/index.jsx
+++ b/packages/pie-toolbox/src/code/editable-html/plugins/html/index.jsx
@@ -2,9 +2,9 @@ import React from 'react';
 import HtmlModeIcon from './icons';
 import { htmlToValue, valueToHtml } from './../../serialization';
 
-const toggleToRichText = (value, onChange) => {
+const toggleToRichText = (value, onChange, dismiss) => {
   const plainText = value.document.text;
-  const slateValue = htmlToValue(plainText);
+  const slateValue = dismiss ? value : htmlToValue(plainText);
 
   const change = value
     .change()
@@ -15,15 +15,17 @@ const toggleToRichText = (value, onChange) => {
 };
 
 export default function HtmlPlugin(opts) {
-  const { isHtmlMode, isEdited, toggleHtmlMode, handleAlertDialog } = opts;
+  const { isHtmlMode, isEditedInHtmlMode, toggleHtmlMode, handleAlertDialog, currentValue } = opts;
 
   const handleHtmlModeOn = (value, onChange) => {
     const dialogProps = {
       title: 'Warning',
-      text: 'Returning to rich text mode may cause edits to be lost.',
+      text: 'Returning to rich text mode without saving will cause edits to be lost.',
+      onConfirmText: 'Dismiss changes',
+      onCloseText: 'Continue Editing',
       onConfirm: () => {
         handleAlertDialog(false);
-        toggleToRichText(value, onChange);
+        toggleToRichText(currentValue, onChange, true);
         toggleHtmlMode();
       },
       onClose: () => {
@@ -53,7 +55,7 @@ export default function HtmlPlugin(opts) {
       type: 'html',
       onClick: (value, onChange) => {
         if (isHtmlMode) {
-          if (isEdited) {
+          if (isEditedInHtmlMode) {
             handleHtmlModeOn(value, onChange);
           } else {
             toggleToRichText(value, onChange);

--- a/packages/pie-toolbox/src/code/editable-html/plugins/toolbar/default-toolbar.jsx
+++ b/packages/pie-toolbox/src/code/editable-html/plugins/toolbar/default-toolbar.jsx
@@ -106,7 +106,7 @@ export const DefaultToolbar = ({
           );
         })}
       </div>
-      {showDone && !deletable && !isHtmlMode && <DoneButton onClick={onDone} />}
+      {showDone && !deletable && <DoneButton onClick={onDone} />}
     </div>
   );
 };


### PR DESCRIPTION
This pull request introduces the following features and improvements:

Preview Dialog for HTML Edits: A new functionality has been implemented where users are presented with a dialog box upon clicking a green 'Done' button. This dialog showcases a preview of the edited HTML, allowing users to either accept or reject the changes. This feature facilitates real-time review and validation before saving any edits made to the HTML.

Enhanced Exit Mechanism: The existing 'exit html' button and its associated alert dialog have been refactored. Users now have a clearer choice post-editing: they can opt to continue editing the HTML or they can revert all changes and return to the WYSIWYG (What You See Is What You Get) mode. This change enhances user control and decision-making regarding their HTML editing process.