### PR TITLE
fix(charting): Fix SVG visibility by overriding global overflow rule in pie-components PD-3271

### DIFF
--- a/packages/pie-toolbox/src/code/charting/common/drag-handle.jsx
+++ b/packages/pie-toolbox/src/code/charting/common/drag-handle.jsx
@@ -26,7 +26,7 @@ const RawDragHandle = ({
   const scaleValue = getScale(width)?.scale;
 
   return (
-    <svg x={x} y={scale.y(y) - 10} width={width} overflow="visible">
+    <svg x={x} y={scale.y(y) - 10} width={width} overflow="visible" style="overflow: visible !important;">
       {isHovered && !correctness && interactive && <DragIcon width={width} scaleValue={scaleValue} color={color} />}
       <circle
         cx={width / 2}

--- a/packages/pie-toolbox/src/code/charting/common/drag-icon.jsx
+++ b/packages/pie-toolbox/src/code/charting/common/drag-icon.jsx
@@ -8,6 +8,7 @@ const DragIcon = ({ width, scaleValue, color }) => (
     color={color}
     overflow="visible"
     filter="url(#svgDropShadow)"
+    style="overflow: visible !important;"
   >
     <defs>
       <filter id="svgDropShadow" x="-20%" y="-20%" width="140%" height="140%">


### PR DESCRIPTION
![image](https://github.com/pie-framework/pie-lib/assets/56835388/bcee236a-7dac-47b0-839e-5da28bcdf528)
