### PR TITLE
fix(charting): Refactor autoFocus handling for category addition PD-3130

### DIFF
--- a/packages/pie-toolbox/src/code/charting/__tests__/__snapshots__/chart.test.jsx.snap
+++ b/packages/pie-toolbox/src/code/charting/__tests__/__snapshots__/chart.test.jsx.snap
@@ -136,6 +136,7 @@ exports[`ChartAxes snapshot renders 1`] = `
         }
       }
       leftAxis={true}
+      onAutoFocusUsed={[Function]}
       onChange={[Function]}
       onChangeCategory={[Function]}
       top={0}
@@ -338,6 +339,7 @@ exports[`ChartAxes snapshot renders if size is not defined 1`] = `
         }
       }
       leftAxis={true}
+      onAutoFocusUsed={[Function]}
       onChange={[Function]}
       onChangeCategory={[Function]}
       top={0}
@@ -544,6 +546,7 @@ exports[`ChartAxes snapshot renders without chartType property 1`] = `
         }
       }
       leftAxis={true}
+      onAutoFocusUsed={[Function]}
       onChange={[Function]}
       onChangeCategory={[Function]}
       top={0}

--- a/packages/pie-toolbox/src/code/charting/axes.jsx
+++ b/packages/pie-toolbox/src/code/charting/axes.jsx
@@ -24,6 +24,12 @@ export class TickComponent extends React.Component {
     };
   }
 
+  componentDidUpdate(prevProps) {
+    if (this.props.autoFocus && !prevProps.autoFocus) {
+      this.props.onAutoFocusUsed();
+    }
+  }
+
   handleAlertDialog = (open, callback) =>
     this.setState(
       {
@@ -126,6 +132,7 @@ export class TickComponent extends React.Component {
       changeInteractiveEnabled,
       changeEditableEnabled,
       error,
+      autoFocus,
     } = this.props;
 
     if (!formattedValue) {
@@ -136,7 +143,7 @@ export class TickComponent extends React.Component {
     const { changeEditable, changeInteractive } = chartingOptions || {};
     const index = parseInt(formattedValue.split('-')[0], 10);
     const category = categories[index];
-    const { deletable, editable, interactive, label, correctness, autoFocus, inDefineChart } = category || {};
+    const { deletable, editable, interactive, label, correctness } = category || {};
     const barX = xBand(bandKey({ label }, index));
     const longestCategory = (categories || []).reduce((a, b) => {
       const lengthA = a && a.label ? a.label.length : 0;
@@ -174,7 +181,7 @@ export class TickComponent extends React.Component {
           )}
 
           <MarkLabel
-            autoFocus={inDefineChart ? defineChart && autoFocus : autoFocus}
+            autoFocus={defineChart && autoFocus}
             inputRef={(r) => (this.input = r)}
             disabled={!defineChart && !editable}
             mark={category}
@@ -377,6 +384,8 @@ export class RawChartAxes extends React.Component {
       changeInteractiveEnabled,
       changeEditableEnabled,
       theme,
+      autoFocus,
+      onAutoFocusUsed,
       error,
     } = this.props;
 
@@ -410,6 +419,8 @@ export class RawChartAxes extends React.Component {
         top,
         defineChart,
         chartingOptions,
+        autoFocus,
+        onAutoFocusUsed,
         error,
         onChangeCategory,
         changeInteractiveEnabled,
@@ -447,6 +458,8 @@ export class RawChartAxes extends React.Component {
           textLabelProps={() => ({ textAnchor: 'middle' })}
           tickFormat={(count) => count}
           tickComponent={getTickComponent}
+          autoFocus={autoFocus}
+          onAutoFocusUsed={onAutoFocusUsed}
         />
       </React.Fragment>
     );

--- a/packages/pie-toolbox/src/code/charting/axes.jsx
+++ b/packages/pie-toolbox/src/code/charting/axes.jsx
@@ -340,6 +340,8 @@ TickComponent.propTypes = {
   chartingOptions: PropTypes.object,
   changeInteractiveEnabled: PropTypes.bool,
   changeEditableEnabled: PropTypes.bool,
+  autoFocus: PropTypes.bool,
+  onAutoFocusUsed: PropTypes.func,
 };
 
 export class RawChartAxes extends React.Component {
@@ -359,6 +361,8 @@ export class RawChartAxes extends React.Component {
     chartingOptions: PropTypes.object,
     changeInteractiveEnabled: PropTypes.bool,
     changeEditableEnabled: PropTypes.bool,
+    autoFocus: PropTypes.bool,
+    onAutoFocusUsed: PropTypes.func,
   };
 
   state = { height: 0 };

--- a/packages/pie-toolbox/src/code/charting/chart.jsx
+++ b/packages/pie-toolbox/src/code/charting/chart.jsx
@@ -88,6 +88,7 @@ export class Chart extends React.Component {
       chartTypes.DotPlot(),
       chartTypes.LinePlot(),
     ],
+    autoFocus: false,
   };
 
   generateMaskId() {
@@ -156,11 +157,11 @@ export class Chart extends React.Component {
         },
       });
     } else {
+      this.setState({ autoFocus: true });
       onDataChange([
         ...data,
         {
           inDefineChart: defineChart,
-          autoFocus: true,
           label: categoryDefaultLabel || translator.t('charting.newLabel', { lng: language }),
           value: 0,
           deletable: true,
@@ -180,6 +181,10 @@ export class Chart extends React.Component {
           deletable: defineChart || d.deletable,
         }))
       : [];
+  };
+
+  resetAutoFocus = () => {
+    this.setState({ autoFocus: false });
   };
 
   render() {
@@ -273,6 +278,8 @@ export class Chart extends React.Component {
         >
           <ChartGrid {...common} xBand={xBand} rowTickValues={horizontalLines} columnTickValues={verticalLines} />
           <ChartAxes
+            autoFocus={this.state.autoFocus}
+            onAutoFocusUsed={this.resetAutoFocus}
             {...common}
             defineChart={defineChart}
             categories={categories}

--- a/packages/pie-toolbox/src/code/charting/common/drag-handle.jsx
+++ b/packages/pie-toolbox/src/code/charting/common/drag-handle.jsx
@@ -26,7 +26,7 @@ const RawDragHandle = ({
   const scaleValue = getScale(width)?.scale;
 
   return (
-    <svg x={x} y={scale.y(y) - 10} width={width} overflow="visible" style="overflow: visible !important;">
+    <svg x={x} y={scale.y(y) - 10} width={width} overflow="visible" style={{ overflow: 'visible !important' }}>
       {isHovered && !correctness && interactive && <DragIcon width={width} scaleValue={scaleValue} color={color} />}
       <circle
         cx={width / 2}

--- a/packages/pie-toolbox/src/code/charting/common/drag-icon.jsx
+++ b/packages/pie-toolbox/src/code/charting/common/drag-icon.jsx
@@ -8,7 +8,7 @@ const DragIcon = ({ width, scaleValue, color }) => (
     color={color}
     overflow="visible"
     filter="url(#svgDropShadow)"
-    style="overflow: visible !important;"
+    style={{ overflow: 'visible !important' }}
   >
     <defs>
       <filter id="svgDropShadow" x="-20%" y="-20%" width="140%" height="140%">


### PR DESCRIPTION
https://illuminate.atlassian.net/jira/software/c/projects/PD/issues/PD-3130?filter=myopenissues

Refactor autoFocus handling for category addition

- Shift autoFocus state management from category data to component state.
- Implement conditional autoFocus logic in child components to ensure focus is applied only once after adding a new category.
- Remove redundant autoFocus properties from category data to prevent unintended focusing on subsequent renders.
- Enhance maintainability and prevent unwanted autofocus behavior.

This change addresses the issue where the previous implementation of embedding autoFocus within category data led to repeated and unwanted autofocus on multiple renders.
