### PR TITLE
fix(charting): enable Category Drag Handle icon on iPad PD-3366

### DIFF
--- a/packages/pie-toolbox/src/code/charting/bars/common/__tests__/__snapshots__/bars.test.jsx.snap
+++ b/packages/pie-toolbox/src/code/charting/bars/common/__tests__/__snapshots__/bars.test.jsx.snap
@@ -43,6 +43,8 @@ exports[`RawBar snapshot renders 1`] = `
 <g
   onMouseEnter={[Function]}
   onMouseLeave={[Function]}
+  onTouchEnd={[Function]}
+  onTouchStart={[Function]}
 >
   <P
     height={NaN}

--- a/packages/pie-toolbox/src/code/charting/bars/common/bars.jsx
+++ b/packages/pie-toolbox/src/code/charting/bars/common/bars.jsx
@@ -130,7 +130,12 @@ export class RawBar extends React.Component {
     const Component = interactive ? DraggableHandle : DragHandle;
 
     return (
-      <g onMouseEnter={this.handleMouseEnter} onMouseLeave={this.handleMouseLeave}>
+      <g
+        onMouseEnter={this.handleMouseEnter}
+        onMouseLeave={this.handleMouseLeave}
+        onTouchStart={this.handleMouseEnter}
+        onTouchEnd={this.handleMouseLeave}
+      >
         <VxBar
           x={barX}
           y={scale.y(yy)}

--- a/packages/pie-toolbox/src/code/charting/common/drag-icon.jsx
+++ b/packages/pie-toolbox/src/code/charting/common/drag-icon.jsx
@@ -7,29 +7,12 @@ const DragIcon = ({ width, scaleValue, color, classes }) => (
     y={getScale(width)?.deltay}
     color={color}
     width={width}
+    height={width}
     overflow="visible"
-    filter="url(#svgDropShadow)"
+    viewBox={`0 0 ${width} ${width}`}
     className={classes.svgOverflowVisible}
   >
-    <defs>
-      <filter id="svgDropShadow" x="-20%" y="-20%" width="140%" height="140%">
-        <feGaussianBlur in="SourceAlpha" stdDeviation="3" />
-        <feOffset dx="0" dy="5" result="offsetblur" />
-        <feFlood floodColor="#00000033" />
-        <feComposite in2="offsetblur" operator="in" />
-        <feMerge>
-          <feMergeNode />
-          <feMergeNode in="SourceGraphic" />
-        </feMerge>
-      </filter>
-    </defs>
-    <g
-      xmlns="http://www.w3.org/2000/svg"
-      filter="url(#filter0_d_2312_1804)"
-      fill="currentColor"
-      stroke="currentColor"
-      transform={`scale(${scaleValue})`}
-    >
+    <g xmlns="http://www.w3.org/2000/svg" fill="currentColor" stroke="currentColor" transform={`scale(${scaleValue})`}>
       <circle cx="28.5" cy="23.5" r="22" fill="white" stroke="currentColor" />
       <path
         d="M33.5 21.25H23.4609C22.7578 21.25 22.4062 20.4297 22.9141 19.9219L27.9141 14.9219C28.2266 14.6094 28.7344 14.6094 29.0469 14.9219L34.0469 19.9219C34.5547 20.4297 34.2031 21.25 33.5 21.25Z"

--- a/packages/pie-toolbox/src/code/charting/plot/common/__tests__/__snapshots__/plot.test.jsx.snap
+++ b/packages/pie-toolbox/src/code/charting/plot/common/__tests__/__snapshots__/plot.test.jsx.snap
@@ -44,6 +44,8 @@ exports[`RawPlot snapshot renders 1`] = `
   <g
     onMouseEnter={[Function]}
     onMouseLeave={[Function]}
+    onTouchEnd={[Function]}
+    onTouchStart={[Function]}
   >
     <WithStyles(RawDragHandle)
       color="var(--pie-primary-dark, #283593)"

--- a/packages/pie-toolbox/src/code/charting/plot/common/plot.jsx
+++ b/packages/pie-toolbox/src/code/charting/plot/common/plot.jsx
@@ -101,7 +101,12 @@ export class RawPlot extends React.Component {
 
     return (
       <React.Fragment>
-        <g onMouseEnter={this.handleMouseEnter} onMouseLeave={this.handleMouseLeave}>
+        <g
+          onMouseEnter={this.handleMouseEnter}
+          onMouseLeave={this.handleMouseLeave}
+          onTouchStart={this.handleMouseEnter}
+          onTouchEnd={this.handleMouseLeave}
+        >
           {isHovered && (
             <rect
               x={barX}


### PR DESCRIPTION
https://illuminate.atlassian.net/browse/PD-3366

Fix involved:
- Removing SVG filters that impaired visibility on iPads.
- Adding explicit 'height' and 'viewBox' attributes to SVGs for better dimension control.
- Replacing hover events with touch events specifically for iPad devices to enhance usability.

This ensures a consistent and interactive experience across various devices.