### PR TITLE
fix(charting): Fix positioning for math-containing labels with fixed positioning addressing a layout issue on various devices, including iPads PD-3367

### DIFF
--- a/packages/pie-toolbox/src/code/charting/mark-label.jsx
+++ b/packages/pie-toolbox/src/code/charting/mark-label.jsx
@@ -136,7 +136,7 @@ export const MarkLabel = (props) => {
         [classes.incorrect]: correctness && correctness.label === 'incorrect',
       })}
       onClick={() => setIsEditing(true)}
-      style={{ minWidth: barWidth }}
+      style={{ minWidth: barWidth, position: 'fixed' }}
     ></div>
   ) : (
     <AutosizeInput


### PR DESCRIPTION
https://illuminate.atlassian.net/browse/PD-3367

Implemented a fix for the positioning of labels containing mathematical expressions by setting their position to 'fixed'. This adjustment specifically addresses a layout issue on various devices, including iPads, where these labels were not correctly aligned within the chart component. By applying 'position: fixed', these math-containing labels are now consistently positioned across different browsers and devices.

Before fix: 
![IMG_0492](https://github.com/pie-framework/pie-lib/assets/56835388/e405b49b-83d1-4f56-90dc-256edbc6da08)
After fix:
![IMG_0491](https://github.com/pie-framework/pie-lib/assets/56835388/c05ef82b-8cce-40f8-aa30-56ff3d9382c5)
