### PR TITLE
fix(math-rendering): Prevent duplicate rendering by skipping math rendering if MathJax is already initialized through math-rendering-accessibility PD-1870

### DIFF
--- a/packages/pie-toolbox/src/code/math-rendering-accessible/mathjax-script.js
+++ b/packages/pie-toolbox/src/code/math-rendering-accessible/mathjax-script.js
@@ -66,6 +66,7 @@ export const initializeMathJax = (renderOpts) => {
         fontURL: 'https://unpkg.com/mathjax-full@3.2.2/ts/output/chtml/fonts/tex-woff-v2',
         displayAlign: 'center',
       },
+      customKey: '@pie-lib/math-rendering-accessible@1',
       options: {
         enableEnrichment: true,
         sre: {

--- a/packages/pie-toolbox/src/code/math-rendering-accessible/render-math.js
+++ b/packages/pie-toolbox/src/code/math-rendering-accessible/render-math.js
@@ -18,7 +18,7 @@ export const getGlobal = () => {
 
   // TODO higher level wrappers use this instance of math-rendering, and if 2 different instances are used, math rendering is not working
   //  so I will hardcode this for now until a better solution is found
-  const key = '@pie-lib/math-rendering@2';
+  const key = '@pie-lib/math-rendering-accessible@1';
 
   if (typeof window !== 'undefined') {
     if (!window[key]) {

--- a/packages/pie-toolbox/src/code/math-rendering/render-math.js
+++ b/packages/pie-toolbox/src/code/math-rendering/render-math.js
@@ -214,6 +214,15 @@ const bootstrap = (opts) => {
 };
 
 const renderMath = (el, renderOpts) => {
+  if (
+    window &&
+    window.MathJax &&
+    window.MathJax.customKey &&
+    window.MathJax.customKey == '@pie-lib/math-rendering-accessible@1'
+  ) {
+    return;
+  }
+
   const isString = typeof el === 'string';
   let executeOn = document.body;
 
@@ -259,9 +268,9 @@ const renderMath = (el, renderOpts) => {
     return;
   }
 
-  if (el instanceof Element && getGlobal().instance) {
+  if (el instanceof Element && getGlobal().instance?.Typeset) {
     getGlobal().instance.Typeset(el);
-  } else if (el.length && getGlobal().instance) {
+  } else if (el.length && getGlobal().instance?.Typeset) {
     const arr = Array.from(el);
     getGlobal().instance.Typeset(...arr);
   }


### PR DESCRIPTION
https://illuminate.atlassian.net/browse/PD-1870