### PR TITLE
fix(charting): change drag handle area into ellipse PD-3501

### DIFF
--- a/packages/pie-toolbox/src/code/charting/common/drag-handle.jsx
+++ b/packages/pie-toolbox/src/code/charting/common/drag-handle.jsx
@@ -25,7 +25,6 @@ const RawDragHandle = ({
   const { scale } = graphProps;
   const scaleValue = getScale(width)?.scale;
 
-  console.log('svg width', width);
   return (
     <svg x={x} y={scale.y(y) - 10} width={width} overflow="visible" className={classes.svgOverflowVisible}>
       {isHovered && !correctness && interactive && (

--- a/packages/pie-toolbox/src/code/charting/common/drag-handle.jsx
+++ b/packages/pie-toolbox/src/code/charting/common/drag-handle.jsx
@@ -25,15 +25,18 @@ const RawDragHandle = ({
   const { scale } = graphProps;
   const scaleValue = getScale(width)?.scale;
 
+  console.log('svg width', width);
   return (
     <svg x={x} y={scale.y(y) - 10} width={width} overflow="visible" className={classes.svgOverflowVisible}>
       {isHovered && !correctness && interactive && (
         <DragIcon width={width} scaleValue={scaleValue} color={color} classes={classes} />
       )}
-      <circle
+      <ellipse
         cx={width / 2}
         cy={10}
-        r={width / 2}
+        rx={width / 2}
+        // the drag icon has a 22px fixed r value, so the ry value is 3 times that in order to cover all the area
+        ry={66}
         className={classNames(classes.transparentHandle, className)}
         {...rest}
       />
@@ -96,7 +99,6 @@ export const DragHandle = withStyles(() => ({
     '&.non-interactive': disabled('fill'),
   },
   transparentHandle: {
-    height: '20px',
     fill: 'transparent',
     clipPath: 'polygon(50% 0%, 100% 0%, 100% 50%, 0% 50%, 0% 0%)',
   },


### PR DESCRIPTION
https://illuminate.atlassian.net/browse/PD-3501
- removed height since it was not doing anything
- changed circle into ellipse (oval shape) because we needed a larger drag area


added a sheer background in these screenshots just to show how the transparent background area is situated with the new changes: 
![Screenshot 2024-03-04 at 12 01 22 PM](https://github.com/pie-framework/pie-lib/assets/61793308/bdfb2150-e485-48bf-a5ec-ced110a7c939)
![Screenshot 2024-03-04 at 12 01 10 PM](https://github.com/pie-framework/pie-lib/assets/61793308/d51fa83a-6887-4d19-b219-9a45a33da750)
