### PR TITLE
fix(math-rendering-accessible): Add initialization for MathJax scriptwhen the legacy math-rendering method isn't detected and the @pie-lib/math-rendering-accessible@1 property is absent from the window object PD-3644

### DIFF
--- a/packages/pie-toolbox/src/code/math-rendering-accessible/render-math.js
+++ b/packages/pie-toolbox/src/code/math-rendering-accessible/render-math.js
@@ -165,7 +165,10 @@ const renderMath = (el, renderOpts) => {
       return;
     }
 
-    if (!window.MathJax && !window.mathjaxLoadedP) {
+    if (
+      (!window.MathJax && !window.mathjaxLoadedP) ||
+      (window.MathJax && !window.hasOwnProperty('@pie-lib/math-rendering-accessible@1'))
+    ) {
       initializeMathJax(renderOpts);
     }
 


### PR DESCRIPTION
https://illuminate.atlassian.net/browse/PD-3644