### PR TITLE
fix(math-rendering-accessible): Add initialization for MathJax script when the legacy math-rendering method isn't detected and the @pie-lib/math-rendering-accessible script is not initialized  PD-3644

### DIFF
--- a/packages/pie-toolbox/src/code/math-rendering-accessible/render-math.js
+++ b/packages/pie-toolbox/src/code/math-rendering-accessible/render-math.js
@@ -169,8 +169,8 @@ const renderMath = (el, renderOpts) => {
 
     if (
       (!window.MathJax && !window.mathjaxLoadedP) ||
-      (window.hasOwnProperty('@pie-lib/math-rendering-accessible@1') &&
-        !window['@pie-lib/math-rendering-accessible@1'].instance)
+      (window.MathJax &&
+        (!window.MathJax.customKey || window.MathJax.customKey !== '@pie-lib/math-rendering-accessible@1'))
     ) {
       initializeMathJax(renderOpts);
     }


### PR DESCRIPTION
https://illuminate.atlassian.net/browse/PD-3644