### PR TITLE
fix(math-rendering-accessible): Refactor package to initiate MathJax loading only if no instance from our legacy or accessibility packages is defined, and to exclusively apply placeholders before MathJax instantiation PD-3683

### DIFF
--- a/packages/pie-toolbox/src/code/math-rendering-accessible/render-math.js
+++ b/packages/pie-toolbox/src/code/math-rendering-accessible/render-math.js
@@ -1,8 +1,8 @@
-import { initializeMathJax } from './mathjax-script';
-import { wrapMath, unWrapMath } from './normalization';
+import {initializeMathJax} from './mathjax-script';
+import {wrapMath, unWrapMath} from './normalization';
 import * as mr from '../math-rendering';
 
-import { SerializedMmlVisitor } from 'mathjax-full/js/core/MmlTree/SerializedMmlVisitor';
+import {SerializedMmlVisitor} from 'mathjax-full/js/core/MmlTree/SerializedMmlVisitor';
 
 const visitor = new SerializedMmlVisitor();
 const toMMl = (node) => visitor.visitTree(node);
@@ -10,25 +10,26 @@ const toMMl = (node) => visitor.visitTree(node);
 const NEWLINE_BLOCK_REGEX = /\\embed\{newLine\}\[\]/g;
 const NEWLINE_LATEX = '\\newline ';
 
+const mathRenderingKEY = '@pie-lib/math-rendering@2';
+const mathRenderingAccessibleKEY = '@pie-lib/math-rendering-accessible@1';
+
+
 export const getGlobal = () => {
-  // TODO does it make sense to use version?
-  // const key = `${pkg.name}@${pkg.version.split('.')[0]}`;
-  // It looks like Ed made this change when he switched from mathjax3 to mathjax-full
-  // I think it was supposed to make sure version 1 (using mathjax3) is not used
-  // in combination with version 2 (using mathjax-full)
-
-  // TODO higher level wrappers use this instance of math-rendering, and if 2 different instances are used, math rendering is not working
-  //  so I will hardcode this for now until a better solution is found
-  const key = '@pie-lib/math-rendering-accessible@1';
-
-  if (typeof window !== 'undefined') {
-    if (!window[key]) {
-      window[key] = {};
+    // TODO does it make sense to use version?
+    // const key = `${pkg.name}@${pkg.version.split('.')[0]}`;
+    // It looks like Ed made this change when he switched from mathjax3 to mathjax-full
+    // I think it was supposed to make sure version 1 (using mathjax3) is not used
+    // in combination with version 2 (using mathjax-full)
+    // TODO higher level wrappers use this instance of math-rendering, and if 2 different instances are used, math rendering is not working
+    //  so I will hardcode this for now until a better solution is found
+    if (typeof window !== 'undefined') {
+        if (!window[mathRenderingAccessibleKEY]) {
+            window[mathRenderingAccessibleKEY] = {};
+        }
+        return window[mathRenderingAccessibleKEY];
+    } else {
+        return {};
     }
-    return window[key];
-  } else {
-    return {};
-  }
 };
 
 /** Add temporary support for a global singleDollar override
@@ -41,227 +42,227 @@ export const getGlobal = () => {
 const defaultOpts = () => getGlobal().opts || {};
 
 export const fixMathElement = (element) => {
-  if (element.dataset.mathHandled) {
-    return;
-  }
+    if (element.dataset.mathHandled) {
+        return;
+    }
 
-  let property = 'innerText';
+    let property = 'innerText';
 
-  if (element.textContent) {
-    property = 'textContent';
-  }
+    if (element.textContent) {
+        property = 'textContent';
+    }
 
-  if (element[property]) {
-    element[property] = wrapMath(unWrapMath(element[property]).unwrapped);
-    // because mathquill doesn't understand line breaks, sometimes we end up with custom elements on prompts/rationale/etc.
-    // we need to replace the custom embedded elements with valid latex that Mathjax can understand
-    element[property] = element[property].replace(NEWLINE_BLOCK_REGEX, NEWLINE_LATEX);
-    element.dataset.mathHandled = true;
-  }
+    if (element[property]) {
+        element[property] = wrapMath(unWrapMath(element[property]).unwrapped);
+        // because mathquill doesn't understand line breaks, sometimes we end up with custom elements on prompts/rationale/etc.
+        // we need to replace the custom embedded elements with valid latex that Mathjax can understand
+        element[property] = element[property].replace(NEWLINE_BLOCK_REGEX, NEWLINE_LATEX);
+        element.dataset.mathHandled = true;
+    }
 };
 
 export const fixMathElements = (el = document) => {
-  const mathElements = el.querySelectorAll('[data-latex]');
+    const mathElements = el.querySelectorAll('[data-latex]');
 
-  mathElements.forEach((item) => fixMathElement(item));
+    mathElements.forEach((item) => fixMathElement(item));
 };
 
 const adjustMathMLStyle = (el = document) => {
-  const nodes = el.querySelectorAll('math');
-  nodes.forEach((node) => node.setAttribute('displaystyle', 'true'));
+    const nodes = el.querySelectorAll('math');
+    nodes.forEach((node) => node.setAttribute('displaystyle', 'true'));
 };
 
 const createPlaceholder = (element) => {
-  if (!element.previousSibling || !element.previousSibling.classList?.contains('math-placeholder')) {
-    // Store the original display style before setting it to 'none'
-    element.dataset.originalDisplay = element.style.display || '';
-    element.style.display = 'none';
+    if (!element.previousSibling || !element.previousSibling.classList?.contains('math-placeholder')) {
+        // Store the original display style before setting it to 'none'
+        element.dataset.originalDisplay = element.style.display || '';
+        element.style.display = 'none';
 
-    const placeholder = document.createElement('span');
-    placeholder.style.cssText =
-      'height: 10px; width: 50px; display: inline-block; vertical-align: middle; justify-content: center; background: #fafafa; border-radius: 4px;';
-    placeholder.classList.add('math-placeholder');
-    element.parentNode?.insertBefore(placeholder, element);
-  }
+        const placeholder = document.createElement('span');
+        placeholder.style.cssText =
+            'height: 10px; width: 50px; display: inline-block; vertical-align: middle; justify-content: center; background: #fafafa; border-radius: 4px;';
+        placeholder.classList.add('math-placeholder');
+        element.parentNode?.insertBefore(placeholder, element);
+    }
 };
 
 const removePlaceholdersAndRestoreDisplay = () => {
-  document.querySelectorAll('.math-placeholder').forEach((placeholder) => {
-    const targetElement = placeholder.nextElementSibling;
+    document.querySelectorAll('.math-placeholder').forEach((placeholder) => {
+        const targetElement = placeholder.nextElementSibling;
 
-    if (targetElement && targetElement.dataset?.originalDisplay !== undefined) {
-      targetElement.style.display = targetElement.dataset.originalDisplay;
-      delete targetElement.dataset.originalDisplay;
-    }
+        if (targetElement && targetElement.dataset?.originalDisplay !== undefined) {
+            targetElement.style.display = targetElement.dataset.originalDisplay;
+            delete targetElement.dataset.originalDisplay;
+        }
 
-    placeholder.remove();
-  });
+        placeholder.remove();
+    });
 };
-
-const waitForMathRenderingLib = (callback) => {
-  // Check immediately if the library is available
-  if (window.hasOwnProperty('@pie-lib/math-rendering@2')) {
-    removePlaceholdersAndRestoreDisplay();
-    return mr.renderMath();
-  }
-
-  if (
-    window.hasOwnProperty('@pie-lib/math-rendering-accessible@1') &&
-    window['@pie-lib/math-rendering-accessible@1'].instance
-  ) {
-    callback();
-    return;
-  }
-
-  let executeOn = document.body;
-  const mathElements = executeOn.querySelectorAll('[data-latex]');
-  mathElements.forEach(createPlaceholder);
-
-  let checkIntervalId;
-  const maxWaitTime = 500;
-  const startTime = Date.now();
-
-  const checkForLib = () => {
-    // Check if library has loaded or if the maximum wait time has been exceeded
-    const hasLibraryLoaded = window.hasOwnProperty('@pie-lib/math-rendering@2');
-    const hasExceededMaxWait = Date.now() - startTime > maxWaitTime;
-
-    if (hasLibraryLoaded || hasExceededMaxWait) {
-      clearInterval(checkIntervalId);
-
-      if (hasLibraryLoaded) {
-        removePlaceholdersAndRestoreDisplay();
-        return mr.renderMath();
-      }
-
-      callback();
-    }
-  };
-
-  // Start periodically checking for math-rendering
-  checkIntervalId = setInterval(checkForLib, 100);
-};
-
 const removeExcessMjxContainers = (content) => {
-  const elements = content.querySelectorAll('[data-latex][data-math-handled="true"]');
+    const elements = content.querySelectorAll('[data-latex][data-math-handled="true"]');
 
-  elements.forEach((element) => {
-    const mjxContainers = element.querySelectorAll('mjx-container');
+    elements.forEach((element) => {
+        const mjxContainers = element.querySelectorAll('mjx-container');
 
-    // Check if there are more than one mjx-container children.
-    if (mjxContainers.length > 1) {
-      for (let i = 1; i < mjxContainers.length; i++) {
-        mjxContainers[i].parentNode.removeChild(mjxContainers[i]);
-      }
-    }
-  });
+        // Check if there are more than one mjx-container children.
+        if (mjxContainers.length > 1) {
+            for (let i = 1; i < mjxContainers.length; i++) {
+                mjxContainers[i].parentNode.removeChild(mjxContainers[i]);
+            }
+        }
+    });
 };
 
 const renderMath = (el, renderOpts) => {
-  // skipWaitForMathRenderingLib is used currently in editable-html, when mmlOutput is enabled
-  const { skipWaitForMathRenderingLib } = renderOpts || {};
+    renderOpts = renderOpts || defaultOpts();
 
-  const isString = typeof el === 'string';
-  let executeOn = document.body;
+    const isString = typeof el === 'string';
+    let executeOn = document.body;
 
-  if (isString) {
-    const div = document.createElement('div');
+    if (isString) {
+        const div = document.createElement('div');
 
-    div.innerHTML = el;
-    executeOn = div;
-  }
-
-  const mathRenderingCallback = () => {
-    fixMathElements(executeOn);
-    adjustMathMLStyle(executeOn);
-
-    if (
-      (!window.MathJax && !window.mathjaxLoadedP) ||
-      (window.hasOwnProperty('@pie-lib/math-rendering-accessible@1') &&
-        !window['@pie-lib/math-rendering-accessible@1'].instance)
-    ) {
-      renderOpts = renderOpts || defaultOpts();
-      initializeMathJax(renderOpts);
+        div.innerHTML = el;
+        executeOn = div;
     }
 
-    if (isString && window.MathJax && window.mathjaxLoadedP) {
-      try {
-        MathJax.texReset();
-        MathJax.typesetClear();
-        window.MathJax.typeset([executeOn]);
-        const updatedDocument = window.MathJax.startup.document;
-        const list = updatedDocument.math.list;
-        const item = list.next;
-        const mathMl = toMMl(item.data.root);
+    const {skipWaitForMathRenderingLib} = renderOpts || {};
 
-        const parsedMathMl = mathMl.replaceAll('\n', '');
+    const renderMathAccessible = () => {
+        fixMathElements(executeOn);
+        adjustMathMLStyle(executeOn);
 
-        return parsedMathMl;
-      } catch (error) {
-        console.error('Error rendering math:', error.message);
-      }
-    }
+        if (
+            (!window.MathJax && !window.mathjaxLoadedP) ||
+            (window.hasOwnProperty(mathRenderingAccessibleKEY) && !window[mathRenderingAccessibleKEY].instance)
+        ) {
+            initializeMathJax(renderOpts);
+        }
 
-    if (window.mathjaxLoadedP) {
-      window.mathjaxLoadedP
-        .then(() => {
-          const mathJaxInstance = getGlobal().instance;
+        if (isString && window.MathJax && window.mathjaxLoadedP) {
+            try {
+                MathJax.texReset();
+                MathJax.typesetClear();
+                window.MathJax.typeset([executeOn]);
+                const updatedDocument = window.MathJax.startup.document;
+                const list = updatedDocument.math.list;
+                const item = list.next;
+                const mathMl = toMMl(item.data.root);
 
-          if (mathJaxInstance) {
-            // Reset and clear typesetting before processing the new content
-            // Reset the tex labels (and automatic equation number).
+                const parsedMathMl = mathMl.replaceAll('\n', '');
 
-            mathJaxInstance.texReset();
+                return parsedMathMl;
+            } catch (error) {
+                console.error('Error rendering math:', error.message);
+            }
+        }
 
-            //  Reset the typesetting system (font caches, etc.)
-            mathJaxInstance.typesetClear();
+        if (window.mathjaxLoadedP) {
+            window.mathjaxLoadedP
+                .then(() => {
+                    const mathJaxInstance = getGlobal().instance;
 
-            // Use typesetPromise for asynchronous typesetting
-            // Using MathJax.typesetPromise() for asynchronous typesetting to handle situations where additional code needs to be loaded (e.g., for certain TeX commands or characters).
-            // This ensures typesetting waits for any needed resources to load and complete processing, unlike the synchronous MathJax.typeset() which can't handle such dynamic loading.
-            mathJaxInstance
-              .typesetPromise([executeOn])
-              .then(() => {
-                try {
-                  removeExcessMjxContainers(executeOn);
-                  removePlaceholdersAndRestoreDisplay();
+                    if (mathJaxInstance) {
+                        // Reset and clear typesetting before processing the new content
+                        // Reset the tex labels (and automatic equation number).
 
-                  const updatedDocument = mathJaxInstance.startup.document;
-                  const list = updatedDocument.math.list;
+                        mathJaxInstance.texReset();
 
-                  for (let item = list.next; typeof item.data !== 'symbol'; item = item.next) {
-                    const mathMl = toMMl(item.data.root);
-                    const parsedMathMl = mathMl.replaceAll('\n', '');
+                        //  Reset the typesetting system (font caches, etc.)
+                        mathJaxInstance.typesetClear();
 
-                    item.data.typesetRoot.setAttribute('data-mathml', parsedMathMl);
-                  }
+                        // Use typesetPromise for asynchronous typesetting
+                        // Using MathJax.typesetPromise() for asynchronous typesetting to handle situations where additional code needs to be loaded (e.g., for certain TeX commands or characters).
+                        // This ensures typesetting waits for any needed resources to load and complete processing, unlike the synchronous MathJax.typeset() which can't handle such dynamic loading.
+                        mathJaxInstance
+                            .typesetPromise([executeOn])
+                            .then(() => {
+                                try {
+                                    removeExcessMjxContainers(executeOn);
+                                    removePlaceholdersAndRestoreDisplay();
 
-                  // If the original input was a string, return the parsed MathML
-                } catch (e) {
-                  console.error('Error post-processing MathJax typesetting:', e.toString());
+                                    const updatedDocument = mathJaxInstance.startup.document;
+                                    const list = updatedDocument.math.list;
+
+                                    for (let item = list.next; typeof item.data !== 'symbol'; item = item.next) {
+                                        const mathMl = toMMl(item.data.root);
+                                        const parsedMathMl = mathMl.replaceAll('\n', '');
+
+                                        item.data.typesetRoot.setAttribute('data-mathml', parsedMathMl);
+                                    }
+
+                                    // If the original input was a string, return the parsed MathML
+                                } catch (e) {
+                                    console.error('Error post-processing MathJax typesetting:', e.toString());
+                                }
+
+                                // Clearing the document if needed
+                                mathJaxInstance.startup.document.clear();
+                            })
+                            .catch((error) => {
+                                //  If there was an internal error, put the message into the output instead
+
+                                console.error('Error in typesetting with MathJax:', error);
+                            });
+                    }
+                })
+                .catch((error) => {
+                    console.error('Error in initializing MathJax:', error);
+                });
+        }
+    };
+
+    // skipWaitForMathRenderingLib is used currently in editable-html, when mmlOutput is enabled
+    if (skipWaitForMathRenderingLib) {
+        // is this case, we don't need to wait for anything, because a math-instance is most probably already loaded
+        return renderMathAccessible();
+    } else {
+        // Check immediately if the math-rendering package is available, and if it is, use it
+        if (window.hasOwnProperty(mathRenderingKEY) && window[mathRenderingKEY].instance) {
+            removePlaceholdersAndRestoreDisplay();
+            return mr.renderMath();
+        }
+
+        // Check immediately if the math-rendering-accessible package is available, and if it is, use it
+        if (window.hasOwnProperty(mathRenderingAccessibleKEY) && window[mathRenderingAccessibleKEY].instance) {
+            return renderMathAccessible();
+
+        }
+
+        const waitForMathRenderingLib = (renderMathAccessibleCallback) => {
+            // Create placeholders for the items while math is loading
+            const mathElements = executeOn.querySelectorAll('[data-latex]');
+            mathElements.forEach(createPlaceholder);
+
+            let checkIntervalId;
+            const maxWaitTime = 500;
+            const startTime = Date.now();
+
+            const checkForLib = () => {
+                // Check if library has loaded or if the maximum wait time has been exceeded
+                const mathRenderingHasLoaded = window.hasOwnProperty(mathRenderingKEY) && window[mathRenderingKEY].instance;
+                const hasExceededMaxWait = Date.now() - startTime > maxWaitTime;
+
+                if (mathRenderingHasLoaded || hasExceededMaxWait) {
+                    clearInterval(checkIntervalId);
+
+                    // Check if the math-rendering package is available, and if it is, use it
+                    if (mathRenderingHasLoaded) {
+                        removePlaceholdersAndRestoreDisplay();
+                        return mr.renderMath();
+                    }
+
+                    renderMathAccessibleCallback();
                 }
+            };
 
-                // Clearing the document if needed
-                mathJaxInstance.startup.document.clear();
-              })
-              .catch((error) => {
-                //  If there was an internal error, put the message into the output instead
+            // Start periodically checking for math-rendering
+            checkIntervalId = setInterval(checkForLib, 100);
+        };
 
-                console.error('Error in typesetting with MathJax:', error);
-              });
-          }
-        })
-        .catch((error) => {
-          console.error('Error in initializing MathJax:', error);
-        });
+        // otherwise, we need for it to load
+        waitForMathRenderingLib(renderMathAccessible);
     }
-  };
-
-  if (skipWaitForMathRenderingLib) {
-    return mathRenderingCallback();
-  } else {
-    waitForMathRenderingLib(mathRenderingCallback);
-  }
 };
 
 export default renderMath;

--- a/packages/pie-toolbox/src/code/math-rendering-accessible/render-math.js
+++ b/packages/pie-toolbox/src/code/math-rendering-accessible/render-math.js
@@ -114,8 +114,6 @@ const removeExcessMjxContainers = (content) => {
 };
 
 const renderMath = (el, renderOpts) => {
-    renderOpts = renderOpts || defaultOpts();
-
     const isString = typeof el === 'string';
     let executeOn = document.body;
 
@@ -128,6 +126,7 @@ const renderMath = (el, renderOpts) => {
 
     const {skipWaitForMathRenderingLib} = renderOpts || {};
 
+    // this is the actual math-rendering-accessible renderMath function, which initialises MathJax
     const renderMathAccessible = () => {
         fixMathElements(executeOn);
         adjustMathMLStyle(executeOn);
@@ -136,6 +135,8 @@ const renderMath = (el, renderOpts) => {
             (!window.MathJax && !window.mathjaxLoadedP) ||
             (window.hasOwnProperty(mathRenderingAccessibleKEY) && !window[mathRenderingAccessibleKEY].instance)
         ) {
+            renderOpts = renderOpts || defaultOpts();
+
             initializeMathJax(renderOpts);
         }
 


### PR DESCRIPTION
https://illuminate.atlassian.net/browse/PD-3683