### PR TITLE
fix(math-editor): Correct font styling for prime notation, resolve issues with prime and double prime notations in the math editor, ensuring they render correctly during authoring and in the final display PD-3537, PD-3540

### DIFF
--- a/packages/pie-toolbox/src/code/math-input/updateSpans.js
+++ b/packages/pie-toolbox/src/code/math-input/updateSpans.js
@@ -5,6 +5,10 @@ const updateSpans = () => {
     if (span && span.innerText === '∥' && span.className !== 'mq-editable-field') {
       span.style.fontSize = '32px';
     }
+
+    if ((span.innerText === '′' || span.innerText === '′′') && !span.hasAttribute('data-prime')) {
+      span.setAttribute('data-prime', 'true');
+    }
   });
 };
 

--- a/packages/pie-toolbox/src/code/math-toolbar/editor-and-pad.jsx
+++ b/packages/pie-toolbox/src/code/math-toolbar/editor-and-pad.jsx
@@ -324,6 +324,7 @@ const styles = (theme) => ({
         right: '-1px',
       },
     },
+
     '& *': {
       fontFamily: 'MJXZERO, MJXTEX !important',
 
@@ -429,6 +430,10 @@ const styles = (theme) => ({
       },
 
       '-webkit-font-smoothing': 'antialiased !important',
+    },
+
+    '& span[data-prime="true"]': {
+      fontFamily: 'Roboto, Helvetica, Arial, sans-serif !important',
     },
   },
   hide: {

--- a/packages/pie-toolbox/src/code/math-toolbar/math-preview.jsx
+++ b/packages/pie-toolbox/src/code/math-toolbar/math-preview.jsx
@@ -180,6 +180,9 @@ const mp = (theme) => ({
     '& .mq-parallelogram': {
       lineHeight: 0.85,
     },
+    '& span[data-prime="true"]': {
+      fontFamily: 'Roboto, Helvetica, Arial, sans-serif !important',
+    },
   },
   selected: {
     border: `solid 1px ${theme.palette.primary.main}`,


### PR DESCRIPTION
https://illuminate.atlassian.net/browse/PD-3540
https://illuminate.atlassian.net/browse/PD-3537