### PR TITLE
fix(mask-markup): Clear MathJax containers and reset LaTeX on markup updates for accurate re-rendering PD-3726

### DIFF
--- a/packages/pie-toolbox/src/code/mask-markup/with-mask.jsx
+++ b/packages/pie-toolbox/src/code/mask-markup/with-mask.jsx
@@ -26,28 +26,30 @@ export const withMask = (type, renderChildren) => {
       onChange: PropTypes.func,
     };
 
-    componentDidUpdate() {
-      // eslint-disable-next-line
-      const domNode = ReactDOM.findDOMNode(this);
-      // Query all elements that may contain outdated MathJax renderings
-      const mathElements = domNode.querySelectorAll('[data-latex][data-math-handled="true"]');
+    componentDidUpdate(prevProps) {
+      if (this.props.markup !== prevProps.markup) {
+        // eslint-disable-next-line
+        const domNode = ReactDOM.findDOMNode(this);
+        // Query all elements that may contain outdated MathJax renderings
+        const mathElements = domNode.querySelectorAll('[data-latex][data-math-handled="true"]');
 
-      // Clean up for fresh MathJax processing
-      mathElements.forEach((el) => {
-        // Remove the MathJax container to allow for clean updates
-        const mjxContainer = el.querySelector('mjx-container');
+        // Clean up for fresh MathJax processing
+        mathElements.forEach((el) => {
+          // Remove the MathJax container to allow for clean updates
+          const mjxContainer = el.querySelector('mjx-container');
 
-        if (mjxContainer) {
-          el.removeChild(mjxContainer);
-        }
+          if (mjxContainer) {
+            el.removeChild(mjxContainer);
+          }
 
-        // Update the innerHTML to match the raw LaTeX data, ensuring it is reprocessed correctly
-        const latexCode = el.getAttribute('data-raw');
-        el.innerHTML = latexCode;
+          // Update the innerHTML to match the raw LaTeX data, ensuring it is reprocessed correctly
+          const latexCode = el.getAttribute('data-raw');
+          el.innerHTML = latexCode;
 
-        // Remove the attribute to signal that MathJax should reprocess this element
-        el.removeAttribute('data-math-handled');
-      });
+          // Remove the attribute to signal that MathJax should reprocess this element
+          el.removeAttribute('data-math-handled');
+        });
+      }
     }
 
     render() {

--- a/packages/pie-toolbox/src/code/mask-markup/with-mask.jsx
+++ b/packages/pie-toolbox/src/code/mask-markup/with-mask.jsx
@@ -31,10 +31,10 @@ export const withMask = (type, renderChildren) => {
         // eslint-disable-next-line
         const domNode = ReactDOM.findDOMNode(this);
         // Query all elements that may contain outdated MathJax renderings
-        const mathElements = domNode.querySelectorAll('[data-latex][data-math-handled="true"]');
+        const mathElements = domNode && domNode.querySelectorAll('[data-latex][data-math-handled="true"]');
 
         // Clean up for fresh MathJax processing
-        mathElements.forEach((el) => {
+        (mathElements || []).forEach((el) => {
           // Remove the MathJax container to allow for clean updates
           const mjxContainer = el.querySelector('mjx-container');
 

--- a/packages/pie-toolbox/src/code/mask-markup/with-mask.jsx
+++ b/packages/pie-toolbox/src/code/mask-markup/with-mask.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 import Mask from './mask';
 import componentize from './componentize';
@@ -24,6 +25,30 @@ export const withMask = (type, renderChildren) => {
       value: PropTypes.object,
       onChange: PropTypes.func,
     };
+
+    componentDidUpdate() {
+      // eslint-disable-next-line
+      const domNode = ReactDOM.findDOMNode(this);
+      // Query all elements that may contain outdated MathJax renderings
+      const mathElements = domNode.querySelectorAll('[data-latex][data-math-handled="true"]');
+
+      // Clean up for fresh MathJax processing
+      mathElements.forEach((el) => {
+        // Remove the MathJax container to allow for clean updates
+        const mjxContainer = el.querySelector('mjx-container');
+
+        if (mjxContainer) {
+          el.removeChild(mjxContainer);
+        }
+
+        // Update the innerHTML to match the raw LaTeX data, ensuring it is reprocessed correctly
+        const latexCode = el.getAttribute('data-raw');
+        el.innerHTML = latexCode;
+
+        // Remove the attribute to signal that MathJax should reprocess this element
+        el.removeAttribute('data-math-handled');
+      });
+    }
 
     render() {
       const { markup, layout, value, onChange } = this.props;


### PR DESCRIPTION
https://illuminate.atlassian.net/browse/PD-3726

The issue described in this ticket affects all items utilizing the mask-markup, including Inline Dropdown, Drag in the Blank, and Constructed Response components. Upon investigation, I determined that this issue predates the current math rendering accessible implementation and can be reproduced in versions from over a year ago. The core of the problem was that changes to the markup did not trigger updates in the MathJax-rendered content. This was due to the pre-existing MathJax containers that were already present in the DOM and were not being reset upon updates. Consequently, MathJax did not recognize these changes, treating the math content as already rendered and thereby skipping the re-rendering process.

The solution involved implementing a mechanism to forcibly clear and reset the MathJax containers whenever the markup changes. We programmatically removed the existing mjx-container elements and reset the data-math-handled attribute on elements needing updates. This adjustment prompted MathJax to recognize the content as new and reprocess it, ensuring the correct display of updated math expressions.