### PR TITLE
fix(editable-html): eliminate custom onFocus and onBlur functions from CustomToolbar component, use them for accessibility (ref PD-2455) only in DefaultToolbar PD-3839

### DIFF
--- a/packages/pie-toolbox/src/code/editable-html/plugins/toolbar/toolbar.jsx
+++ b/packages/pie-toolbox/src/code/editable-html/plugins/toolbar/toolbar.jsx
@@ -146,7 +146,8 @@ export class Toolbar extends React.Component {
       isFocused,
       onDone,
       toolbarRef,
-      onBlur, onFocus
+      onBlur,
+      onFocus,
     } = this.props;
 
     const node = findSingleNode(value);
@@ -235,8 +236,6 @@ export class Toolbar extends React.Component {
             onToolbarDone={this.onToolbarDone}
             onDataChange={handleDataChange}
             pluginProps={pluginProps}
-            onFocus={onFocus}
-        onBlur={onBlur}
           />
         ) : (
           <DefaultToolbar
@@ -250,7 +249,7 @@ export class Toolbar extends React.Component {
             deletable={deletable}
             isHtmlMode={toolbarOpts.isHtmlMode}
             onFocus={onFocus}
-        onBlur={onBlur}
+            onBlur={onBlur}
           />
         )}
 


### PR DESCRIPTION
https://illuminate.atlassian.net/browse/PD-3839