### PR TITLE
fix(editable-html): prevent editor from regaining focus when using Spanish or special character keypad PD-3834

### DIFF
--- a/packages/pie-toolbox/src/code/editable-html/editor.jsx
+++ b/packages/pie-toolbox/src/code/editable-html/editor.jsx
@@ -646,6 +646,11 @@ export class Editor extends React.Component {
     }, 50);
   };
 
+  isRelatedTargetButton(event) {
+    const relatedTarget = event?.relatedTarget;
+    return relatedTarget && relatedTarget.tagName.toLowerCase() === 'button';
+  }
+
   /*
    * Needs to be wrapped otherwise it causes issues because of race conditions
    * Known issue for slatejs. See: https://github.com/ianstormtaylor/slate/issues/2097
@@ -690,7 +695,9 @@ export class Editor extends React.Component {
       this.props.onFocus();
 
       // Added for accessibility: Ensures the editor gains focus when tabbed to for improved keyboard navigation
-      change?.focus();
+      if (!this.isRelatedTargetButton(event)) {
+        change?.focus();
+      }
 
       resolve();
     });

--- a/packages/pie-toolbox/src/code/editable-html/plugins/toolbar/__tests__/__snapshots__/editor-and-toolbar.test.jsx.snap
+++ b/packages/pie-toolbox/src/code/editable-html/plugins/toolbar/__tests__/__snapshots__/editor-and-toolbar.test.jsx.snap
@@ -3,6 +3,7 @@
 exports[`toolbar renders 1`] = `
 <div
   className="root"
+  tabIndex={0}
 >
   <div
     className="editorHolder editorInFocus"

--- a/packages/pie-toolbox/src/code/editable-html/plugins/toolbar/editor-and-toolbar.jsx
+++ b/packages/pie-toolbox/src/code/editable-html/plugins/toolbar/editor-and-toolbar.jsx
@@ -82,6 +82,7 @@ export class EditorAndToolbar extends React.Component {
 
     return (
       <div
+        tabIndex={0}
         className={classNames(
           {
             [classes.noBorder]: toolbarOpts && toolbarOpts.noBorder,


### PR DESCRIPTION
https://illuminate.atlassian.net/browse/PD-3834
 related: https://illuminate.atlassian.net/browse/PD-2455
 
Added a condition to check if the related target is a button before focusing the editor. This prevents the editor from stealing focus when interacting with the special character keypad or other toolbar buttons.