### PR TITLE
fix(drag-in-the-blank): prevent line wrapping for response area PD-3653

### DIFF
--- a/packages/pie-toolbox/src/code/mask-markup/components/blank.jsx
+++ b/packages/pie-toolbox/src/code/mask-markup/components/blank.jsx
@@ -17,6 +17,7 @@ const useStyles = withStyles(() => ({
     minWidth: '200px',
     touchAction: 'none',
     overflow: 'hidden',
+    whiteSpace: 'nowrap', // Prevent line wrapping
   },
   chip: {
     backgroundColor: color.background(),


### PR DESCRIPTION
https://illuminate.atlassian.net/browse/PD-3653
There was this edge case that only happens when the response area had no space after the next content causing layout problems at dragging.
Before the fix:

https://github.com/pie-framework/pie-lib/assets/26737238/ffd6ccb3-2c97-4a6d-a952-999e2c5a7bca

After the fix:
because of the 'whitespace: nowrap' attribute the whole content: (response area + .) was moved in the next line.
https://github.com/pie-framework/pie-lib/assets/26737238/e1c250d7-f88b-4f94-a525-37e5fbfe04d8

