### PR TITLE
fix(charting): Evaluate should not mark up category labels as correct/incorrect when they are not editable PD-3799

### DIFF
--- a/packages/pie-toolbox/src/code/charting/mark-label.jsx
+++ b/packages/pie-toolbox/src/code/charting/mark-label.jsx
@@ -133,8 +133,8 @@ export const MarkLabel = (props) => {
       className={classNames(classes.mathInput, {
         [classes.disabled]: disabled,
         [classes.error]: error,
-        [classes.correct]: correctness && correctness.label === 'correct',
-        [classes.incorrect]: correctness && correctness.label === 'incorrect',
+        [classes.correct]: mark.editable && correctness?.label === 'correct',
+        [classes.incorrect]: mark.editable && correctness?.label === 'incorrect',
       })}
       onClick={() => setIsEditing(true)}
       style={{ minWidth: barWidth, position: 'fixed' }}
@@ -149,7 +149,7 @@ export const MarkLabel = (props) => {
       disabled={disabled}
       inputClassName={classNames(
         classes.input,
-        correctness && correctness.label,
+        correctness && mark.editable ? correctness.label : null,
         disabled && 'disabled',
         error && 'error',
       )}


### PR DESCRIPTION
https://illuminate.atlassian.net/browse/PD-3799

![image](https://github.com/pie-framework/pie-lib/assets/26737238/1aa7f91e-6c78-4a11-b87b-b59d8b6c3630)

With the fix:
https://github.com/pie-framework/pie-lib/assets/26737238/7808fea7-b0b0-4217-9e8e-69c108ff8ff5



