### PR TITLE
fix(graphing): Prevent editor from gaining focus after clicking Done on axis labels PD-3924

### DIFF
--- a/packages/pie-toolbox/src/code/editable-html/__tests__/editor.test.jsx
+++ b/packages/pie-toolbox/src/code/editable-html/__tests__/editor.test.jsx
@@ -67,6 +67,26 @@ test('onFocus stashes the value', async () => {
   expect(wrapper.state('stashedValue')).toEqualHtml('<div>hi</div>');
 });
 
+test('onBlur does not set focusToolbar if related target is RawDoneButton', async () => {
+  const wrapper = shallow(
+    <Editor editorRef={jest.fn()} value={value} classes={{}} onChange={jest.fn()} onRef={jest.fn()} />,
+  );
+
+  const toolbarElement = document.createElement('div');
+  const relatedTarget = document.createElement('button');
+  relatedTarget.className = 'RawDoneButton';
+  toolbarElement.className = 'toolbar';
+  toolbarElement.appendChild(relatedTarget);
+
+  wrapper.instance().toolbarRef = toolbarElement;
+
+  const event = { relatedTarget };
+
+  await wrapper.instance().onBlur(event);
+
+  expect(wrapper.state('focusToolbar')).toBe(false);
+});
+
 describe('buildSizeStyle', () => {
   const wrapper = (extras) => {
     const props = Object.assign({}, extras);

--- a/packages/pie-toolbox/src/code/editable-html/editor.jsx
+++ b/packages/pie-toolbox/src/code/editable-html/editor.jsx
@@ -602,7 +602,10 @@ export class Editor extends React.Component {
     const relatedTarget = event.relatedTarget;
     const toolbarElement = this.toolbarRef && relatedTarget?.closest(`[class*="${this.toolbarRef.className}"]`);
 
-    if (toolbarElement) {
+    // Check if relatedTarget is a done button
+    const isRawDoneButton = relatedTarget?.closest('button[class*="RawDoneButton"]');
+
+    if (toolbarElement && !isRawDoneButton) {
       this.setState({
         focusToolbar: true,
       });


### PR DESCRIPTION
https://illuminate.atlassian.net/browse/PD-3924

This resolves the issue where the editable HTML labels on the graph remain editable and move back to the left after clicking the done mark, which should finalize the label position and stop editing.