### PR TITLE
fix(editable-html): introduce setActiveKeypad utility for consistent keypad lifecycle management, this utility ensures that only one keypad remains active at any time by automatically closing any previously active keypad when a new one is set PD-3630

### DIFF
--- a/packages/pie-toolbox/src/code/editable-html/plugins/characters/index.jsx
+++ b/packages/pie-toolbox/src/code/editable-html/plugins/characters/index.jsx
@@ -8,6 +8,7 @@ import { PureToolbar } from '../../../math-toolbar';
 import CustomPopper from './custom-popper';
 import { insertSnackBar } from '../respArea/utils';
 import { characterIcons, spanishConfig, specialConfig } from './utils';
+import { setActiveKeypad } from './../utils';
 import PropTypes from 'prop-types';
 
 const log = debug('@pie-lib:editable-html:plugins:characters');
@@ -33,6 +34,7 @@ const insertDialog = ({ editorDOM, value, callback, opts }) => {
   log('[characters:insertDialog]');
 
   removeDialogs();
+  setActiveKeypad({ close: () => newEl.remove() });
 
   newEl.className = 'insert-character-dialog';
 

--- a/packages/pie-toolbox/src/code/editable-html/plugins/math/index.jsx
+++ b/packages/pie-toolbox/src/code/editable-html/plugins/math/index.jsx
@@ -2,6 +2,7 @@ import Functions from '@material-ui/icons/Functions';
 import { Inline } from 'slate';
 import { MathPreview, MathToolbar } from '../../../math-toolbar';
 import { wrapMath, unWrapMath, mmlToLatex, renderMath } from '../../../math-rendering-accessible';
+import { setActiveKeypad, closeActiveKeypad } from './../utils';
 import React from 'react';
 import debug from 'debug';
 import SlatePropTypes from 'slate-prop-types';
@@ -36,6 +37,9 @@ export const CustomToolbarComp = React.memo(
         ...node.data.toObject(),
         latex,
       };
+
+      closeActiveKeypad();
+
       const change = value.change().setNodeByKey(node.key, { data: update });
 
       const nextText = value.document.getNextText(node.key);
@@ -112,6 +116,7 @@ export default function MathPlugin(opts) {
         const math = inlineMath();
         const change = value.change().insertInline(math);
         onChange(change);
+        setActiveKeypad({ close: () => onChange(change) });
       },
       supports: (node) => node && node.object === 'inline' && node.type === 'math',
       /**

--- a/packages/pie-toolbox/src/code/editable-html/plugins/utils.js
+++ b/packages/pie-toolbox/src/code/editable-html/plugins/utils.js
@@ -29,3 +29,19 @@ export const hasMark = (value, type) => value && value.marks.some((mark) => mark
 export const hasBlock = (value, type) => value && value.blocks.some((node) => node.type == type);
 
 export const hasNode = ({ document }, type) => document && document.nodes.some((node) => node.type == type);
+
+let activeKeypad = null;
+
+export const setActiveKeypad = (keypad) => {
+  if (activeKeypad && activeKeypad !== keypad) {
+    activeKeypad.close();
+  }
+  activeKeypad = keypad;
+};
+
+export const closeActiveKeypad = () => {
+  if (activeKeypad) {
+    activeKeypad.close();
+    activeKeypad = null;
+  }
+};


### PR DESCRIPTION
https://illuminate.atlassian.net/browse/PD-3630