### PR TITLE
feat(drag-in-the-blank): use right-angle corners for answer choices & response areas PD-3950

### DIFF
--- a/packages/pie-toolbox/src/code/mask-markup/choices/choice.jsx
+++ b/packages/pie-toolbox/src/code/mask-markup/choices/choice.jsx
@@ -79,6 +79,7 @@ export const BlankContent = withStyles((theme) => ({
     // This will prevent the context menu from appearing and not allowing other interactions with the image.
     // If interactions with the image in the token will be requested we should handle only the context Menu.
     pointerEvents: 'none',
+    borderRadius: '3px'
   },
   chipLabel: {
     whiteSpace: 'pre-wrap',

--- a/packages/pie-toolbox/src/code/mask-markup/components/blank.jsx
+++ b/packages/pie-toolbox/src/code/mask-markup/components/blank.jsx
@@ -29,6 +29,7 @@ const useStyles = withStyles(() => ({
     height: 'auto',
     maxWidth: '374px',
     position: 'relative',
+    borderRadius: '3px'
   },
   chipLabel: {
     whiteSpace: 'pre-wrap',


### PR DESCRIPTION
https://illuminate.atlassian.net/browse/PD-3950

The corners are now just a slightly round in order to match the choices and response areas from the authoring view
![Screenshot 2024-07-17 at 14 43 33](https://github.com/user-attachments/assets/84a6be33-114d-4859-aee7-f1f99e0bc226)
