### PR TITLE
fix(editable-html): remove tabindex from editor-and-toolbar componentas it was causing an issue where two tab presses were required to focus on the editor PD-2451

### DIFF
--- a/packages/pie-toolbox/src/code/editable-html/plugins/toolbar/__tests__/__snapshots__/editor-and-toolbar.test.jsx.snap
+++ b/packages/pie-toolbox/src/code/editable-html/plugins/toolbar/__tests__/__snapshots__/editor-and-toolbar.test.jsx.snap
@@ -3,7 +3,6 @@
 exports[`toolbar renders 1`] = `
 <div
   className="root"
-  tabIndex={0}
 >
   <div
     className="editorHolder editorInFocus"

--- a/packages/pie-toolbox/src/code/editable-html/plugins/toolbar/editor-and-toolbar.jsx
+++ b/packages/pie-toolbox/src/code/editable-html/plugins/toolbar/editor-and-toolbar.jsx
@@ -82,7 +82,6 @@ export class EditorAndToolbar extends React.Component {
 
     return (
       <div
-        tabIndex={0}
         className={classNames(
           {
             [classes.noBorder]: toolbarOpts && toolbarOpts.noBorder,


### PR DESCRIPTION
https://illuminate.atlassian.net/browse/PD-2451