### PR TITLE
Feat(categorize,drag-in-the-blank,ica,match-list): "pool" area changes

### DIFF
--- a/packages/pie-toolbox/src/code/drag/placeholder.jsx
+++ b/packages/pie-toolbox/src/code/drag/placeholder.jsx
@@ -79,10 +79,11 @@ const styles = (theme) => ({
     display: 'flex',
     flexWrap: 'wrap',
     alignItems: 'center',
-    minHeight: '200px',
+    minHeight: '100px',
     justifyContent: 'center',
     overflow: 'hidden',
     touchAction: 'none',
+    backgroundColor: '#ECEDF1',
   },
   categorizeBoard: {
     border: '1px solid #D1D1D1',
@@ -94,6 +95,7 @@ const styles = (theme) => ({
     justifyContent: 'center',
     overflow: 'hidden',
     touchAction: 'none',
+    backgroundColor: '#ECEDF1',
   },
 });
 

--- a/packages/pie-toolbox/src/code/drag/placeholder.jsx
+++ b/packages/pie-toolbox/src/code/drag/placeholder.jsx
@@ -83,7 +83,7 @@ const styles = (theme) => ({
     justifyContent: 'center',
     overflow: 'hidden',
     touchAction: 'none',
-    backgroundColor: color.defaults.BACKGROUND_DARK,
+    backgroundColor: color.backgroundDark(),
   },
   categorizeBoard: {
     padding: theme.spacing.unit / 2,
@@ -94,7 +94,7 @@ const styles = (theme) => ({
     justifyContent: 'center',
     overflow: 'hidden',
     touchAction: 'none',
-    backgroundColor: color.defaults.BACKGROUND_DARK,
+    backgroundColor: color.backgroundDark(),
   },
 });
 

--- a/packages/pie-toolbox/src/code/drag/placeholder.jsx
+++ b/packages/pie-toolbox/src/code/drag/placeholder.jsx
@@ -3,6 +3,7 @@ import { withStyles } from '@material-ui/core/styles';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import grey from '@material-ui/core/colors/grey';
+import { color } from '../render-ui';
 
 export const PlaceHolder = (props) => {
   const { children, classes, className, isOver, type, grid, disabled, choiceBoard, isCategorize } = props;
@@ -82,7 +83,7 @@ const styles = (theme) => ({
     justifyContent: 'center',
     overflow: 'hidden',
     touchAction: 'none',
-    backgroundColor: '#ECEDF1',
+    backgroundColor: color.defaults.BACKGROUND_DARK,
   },
   categorizeBoard: {
     padding: theme.spacing.unit / 2,
@@ -93,7 +94,7 @@ const styles = (theme) => ({
     justifyContent: 'center',
     overflow: 'hidden',
     touchAction: 'none',
-    backgroundColor: '#ECEDF1',
+    backgroundColor: color.defaults.BACKGROUND_DARK,
   },
 });
 

--- a/packages/pie-toolbox/src/code/drag/placeholder.jsx
+++ b/packages/pie-toolbox/src/code/drag/placeholder.jsx
@@ -74,7 +74,6 @@ const styles = (theme) => ({
     backgroundColor: `${grey[300]}`,
   },
   board: {
-    border: '1px solid #D1D1D1',
     padding: theme.spacing.unit,
     display: 'flex',
     flexWrap: 'wrap',
@@ -86,7 +85,6 @@ const styles = (theme) => ({
     backgroundColor: '#ECEDF1',
   },
   categorizeBoard: {
-    border: '1px solid #D1D1D1',
     padding: theme.spacing.unit / 2,
     display: 'flex',
     flexWrap: 'wrap',

--- a/packages/pie-toolbox/src/code/mask-markup/choices/choice.jsx
+++ b/packages/pie-toolbox/src/code/mask-markup/choices/choice.jsx
@@ -65,7 +65,7 @@ export const BlankContent = withStyles((theme) => ({
     transform: 'translate(0, 0)',
   },
   chip: {
-    backgroundColor: color.background(),
+    backgroundColor: '#ffffff',
     border: `1px solid ${color.text()}`,
     color: color.text(),
     alignItems: 'center',

--- a/packages/pie-toolbox/src/code/mask-markup/choices/choice.jsx
+++ b/packages/pie-toolbox/src/code/mask-markup/choices/choice.jsx
@@ -65,7 +65,7 @@ export const BlankContent = withStyles((theme) => ({
     transform: 'translate(0, 0)',
   },
   chip: {
-    backgroundColor: '#ffffff',
+    backgroundColor: color.background(),
     border: `1px solid ${color.text()}`,
     color: color.text(),
     alignItems: 'center',


### PR DESCRIPTION
Avoid allocating more vertical space & provide a light gray fill (#ECEDF1) for the answer choice “pool” area
Screenshots are provided in the ticket:
https://illuminate.atlassian.net/browse/PD-3944