### PR TITLE
Feat(categorize,drag-in-the-blank,match-list,placement-ordering) empty response area changes - dashed black stroke with a white fill 

### DIFF
--- a/packages/pie-toolbox/src/code/drag/placeholder.jsx
+++ b/packages/pie-toolbox/src/code/drag/placeholder.jsx
@@ -56,7 +56,7 @@ const styles = (theme) => ({
   placeholder: {
     width: '100%',
     height: '100%',
-    background: theme.palette.grey[200],
+    background: '#ffffff',
     border: '1px solid #D1D1D1',
     transition: 'background-color 200ms linear, border-color 200ms linear',
     boxSizing: 'border-box',
@@ -64,6 +64,7 @@ const styles = (theme) => ({
     gridRowGap: `${theme.spacing.unit}px`,
     gridColumnGap: `${theme.spacing.unit}px`,
     padding: theme.spacing.unit * 1,
+    border: '2px dashed #000000',
   },
   disabled: {
     boxShadow: 'none',

--- a/packages/pie-toolbox/src/code/drag/placeholder.jsx
+++ b/packages/pie-toolbox/src/code/drag/placeholder.jsx
@@ -32,8 +32,8 @@ export const PlaceHolder = (props) => {
   // We apply a different style for the "choice" type
   // For any other type, use a dashed black border and a white fill
   if (type === 'choice') {
-    style.border = '1px solid #D1D1D1';
-    style.background = '#eeeeee';
+    style.border = `1px solid ${color.borderLight()}`;
+    style.background = color.backgroundDark();
   }
 
   const boardStyle = isCategorize ? classes.categorizeBoard : classes.board;
@@ -67,14 +67,14 @@ const styles = (theme) => ({
   placeholder: {
     width: '100%',
     height: '100%',
-    background: '#ffffff',
+    background: color.white(),
     transition: 'background-color 200ms linear, border-color 200ms linear',
     boxSizing: 'border-box',
     display: 'grid',
     gridRowGap: `${theme.spacing.unit}px`,
     gridColumnGap: `${theme.spacing.unit}px`,
     padding: theme.spacing.unit * 1,
-    border: '2px dashed #000000',
+    border: `2px dashed ${color.black()}`,
   },
   disabled: {
     boxShadow: 'none',

--- a/packages/pie-toolbox/src/code/drag/placeholder.jsx
+++ b/packages/pie-toolbox/src/code/drag/placeholder.jsx
@@ -26,11 +26,11 @@ export const PlaceHolder = (props) => {
     style.gridTemplateRows = `repeat(${grid.rows}, ${repeatValue})`;
   }
   
-  // type is only sent thorugh placement-ordering / placeholder
-  // it can be "choice" or "target"
-  // we apply a different style for the "choice" type 
-  // otherwise use the dashed border black and fill white
-  if(type === 'choice'){
+  // The "type" is only sent through placement-ordering / placeholder
+  // It can be "choice" or "target"
+  // We apply a different style for the "choice" type
+  // For any other type, use a dashed black border and a white fill
+  if (type === 'choice') {
     style.border = '1px solid #D1D1D1';
     style.background = '#eeeeee';
   }

--- a/packages/pie-toolbox/src/code/drag/placeholder.jsx
+++ b/packages/pie-toolbox/src/code/drag/placeholder.jsx
@@ -19,10 +19,20 @@ export const PlaceHolder = (props) => {
   if (grid && grid.columns) {
     style.gridTemplateColumns = `repeat(${grid.columns}, 1fr)`;
   }
+  
   if (grid && grid.rows) {
     const repeatValue = grid.rowsRepeatValue || '1fr';
 
     style.gridTemplateRows = `repeat(${grid.rows}, ${repeatValue})`;
+  }
+  
+  // type is only sent thorugh placement-ordering / placeholder
+  // it can be "choice" or "target"
+  // we apply a different style for the "choice" type 
+  // otherwise use the dashed border black and fill white
+  if(type === 'choice'){
+    style.border = '1px solid #D1D1D1';
+    style.background = '#eeeeee';
   }
 
   const boardStyle = isCategorize ? classes.categorizeBoard : classes.board;
@@ -57,7 +67,6 @@ const styles = (theme) => ({
     width: '100%',
     height: '100%',
     background: '#ffffff',
-    border: '1px solid #D1D1D1',
     transition: 'background-color 200ms linear, border-color 200ms linear',
     boxSizing: 'border-box',
     display: 'grid',

--- a/packages/pie-toolbox/src/code/mask-markup/components/blank.jsx
+++ b/packages/pie-toolbox/src/code/mask-markup/components/blank.jsx
@@ -20,7 +20,7 @@ const useStyles = withStyles(() => ({
     whiteSpace: 'nowrap', // Prevent line wrapping
   },
   chip: {
-    backgroundColor: color.background(),
+    backgroundColor: '#ffffff',
     border: `2px dashed ${color.text()}`,
     color: color.text(),
     minWidth: '90px',

--- a/packages/pie-toolbox/src/code/mask-markup/components/blank.jsx
+++ b/packages/pie-toolbox/src/code/mask-markup/components/blank.jsx
@@ -20,7 +20,7 @@ const useStyles = withStyles(() => ({
     whiteSpace: 'nowrap', // Prevent line wrapping
   },
   chip: {
-    backgroundColor: '#ffffff',
+    backgroundColor: color.background(),
     border: `2px dashed ${color.text()}`,
     color: color.text(),
     minWidth: '90px',

--- a/packages/pie-toolbox/src/code/mask-markup/components/blank.jsx
+++ b/packages/pie-toolbox/src/code/mask-markup/components/blank.jsx
@@ -21,7 +21,7 @@ const useStyles = withStyles(() => ({
   },
   chip: {
     backgroundColor: color.background(),
-    border: `1px solid ${color.text()}`,
+    border: `2px dashed ${color.text()}`,
     color: color.text(),
     minWidth: '90px',
     fontSize: 'inherit',


### PR DESCRIPTION
This story is to change the Gather and authoring empty response area design treatment for these item types to a dashed black stroke with a white fill: 
categorize
drag-in-the-blank
match-list
placement-ordering (when "placementArea" is true)

More details can be found in the task's description: 
https://illuminate.atlassian.net/browse/PD-3946