### PR TITLE
feat(editable-html): Add accessible label to extended-text-entry, response-area editor for improved accessibility PD-2450

### DIFF
--- a/packages/pie-toolbox/src/code/editable-html/editor.jsx
+++ b/packages/pie-toolbox/src/code/editable-html/editor.jsx
@@ -990,68 +990,81 @@ export class Editor extends React.Component {
       },
       className,
     );
+    const isResponseAreaEditor = names.includes('response-area-editor');
 
     return (
-      <div ref={(ref) => (this.wrapperRef = ref)} style={{ width: sizeStyle.width }} className={names}>
-        {scheduled && <div className={classes.uploading}>Uploading image and then saving...</div>}
-        <SlateEditor
-          plugins={this.plugins}
-          innerRef={(r) => {
-            if (r) {
-              this.slateEditor = r;
-            }
-          }}
-          ref={(r) => (this.editor = r && this.props.editorRef(r))}
-          toolbarRef={(r) => {
-            if (r) {
-              this.toolbarRef = r;
-            }
-          }}
-          value={value}
-          focusToolbar={this.state.focusToolbar}
-          onToolbarFocus={this.handleToolbarFocus}
-          onToolbarBlur={this.handleToolbarBlur}
-          focus={this.focus}
-          onKeyDown={onKeyDown}
-          onChange={this.onChange}
-          getFocusedValue={this.getFocusedValue}
-          onBlur={this.onBlur}
-          onDrop={(event, editor) => this.onDropPaste(event, editor, true)}
-          onPaste={(event, editor) => this.onDropPaste(event, editor)}
-          onFocus={this.onFocus}
-          onEditingDone={this.onEditingDone}
-          focusedNode={focusedNode}
-          normalize={this.normalize}
-          readOnly={disabled}
-          spellCheck={spellCheck}
-          autoCorrect={spellCheck}
-          className={classNames(
-            {
-              [classes.noPadding]: toolbarOpts && toolbarOpts.noBorder,
-            },
-            classes.slateEditor,
-          )}
-          style={{
-            minHeight: sizeStyle.minHeight,
-            height: sizeStyle.height,
-            maxHeight: sizeStyle.maxHeight,
-          }}
-          pluginProps={otherPluginProps}
-          toolbarOpts={toolbarOpts}
-          placeholder={placeholder}
-          renderPlaceholder={this.renderPlaceholder}
-          onDataChange={this.changeData}
-        />
-        <AlertDialog
-          open={dialog.open}
-          title={dialog.title}
-          text={dialog.text}
-          onClose={dialog.onClose}
-          onConfirm={dialog.onConfirm}
-          onConfirmText={dialog.onConfirmText}
-          onCloseText={dialog.onCloseText}
-        />
-      </div>
+      <>
+        {isResponseAreaEditor && (
+          <label htmlFor={`editor-${value?.document?.key}`} className={classes.srOnly}>
+            Answer:
+          </label>
+        )}
+        <div
+          ref={(ref) => (this.wrapperRef = ref)}
+          style={{ width: sizeStyle.width }}
+          className={names}
+          id={`editor-${value?.document?.key}`}
+        >
+          {scheduled && <div className={classes.uploading}>Uploading image and then saving...</div>}
+          <SlateEditor
+            plugins={this.plugins}
+            innerRef={(r) => {
+              if (r) {
+                this.slateEditor = r;
+              }
+            }}
+            ref={(r) => (this.editor = r && this.props.editorRef(r))}
+            toolbarRef={(r) => {
+              if (r) {
+                this.toolbarRef = r;
+              }
+            }}
+            value={value}
+            focusToolbar={this.state.focusToolbar}
+            onToolbarFocus={this.handleToolbarFocus}
+            onToolbarBlur={this.handleToolbarBlur}
+            focus={this.focus}
+            onKeyDown={onKeyDown}
+            onChange={this.onChange}
+            getFocusedValue={this.getFocusedValue}
+            onBlur={this.onBlur}
+            onDrop={(event, editor) => this.onDropPaste(event, editor, true)}
+            onPaste={(event, editor) => this.onDropPaste(event, editor)}
+            onFocus={this.onFocus}
+            onEditingDone={this.onEditingDone}
+            focusedNode={focusedNode}
+            normalize={this.normalize}
+            readOnly={disabled}
+            spellCheck={spellCheck}
+            autoCorrect={spellCheck}
+            className={classNames(
+              {
+                [classes.noPadding]: toolbarOpts && toolbarOpts.noBorder,
+              },
+              classes.slateEditor,
+            )}
+            style={{
+              minHeight: sizeStyle.minHeight,
+              height: sizeStyle.height,
+              maxHeight: sizeStyle.maxHeight,
+            }}
+            pluginProps={otherPluginProps}
+            toolbarOpts={toolbarOpts}
+            placeholder={placeholder}
+            renderPlaceholder={this.renderPlaceholder}
+            onDataChange={this.changeData}
+          />
+          <AlertDialog
+            open={dialog.open}
+            title={dialog.title}
+            text={dialog.text}
+            onClose={dialog.onClose}
+            onConfirm={dialog.onConfirm}
+            onConfirmText={dialog.onConfirmText}
+            onCloseText={dialog.onCloseText}
+          />
+        </div>
+      </>
     );
   }
 }
@@ -1108,6 +1121,16 @@ const styles = {
     marginTop: '6px',
     padding: '20px',
     backgroundColor: 'rgba(0,0,0,0.06)',
+  },
+  srOnly: {
+    border: 0,
+    clip: 'rect(0, 0, 0, 0)',
+    height: '1px',
+    margin: '-1px',
+    overflow: 'hidden',
+    padding: 0,
+    position: 'absolute',
+    width: '1px',
   },
 };
 


### PR DESCRIPTION
https://illuminate.atlassian.net/browse/PD-2450

- Added a `label` element with a `for` attribute to the editor wrapper to associate it with the editor for accessibility purposes.
- Included an `id` attribute in the editor's container `div` to match the `for` attribute in the `label`.
- Ensured the `label` is conditionally rendered only if the editor is a response-area-editor in extended-text-entry
- Styled the `label` with `srOnly` class to visually hide it but keep it accessible for screen readers.