### PR TITLE
fix(editable-html): add Response Area button when the cursor is positioned in a table PD-3996

### DIFF
--- a/packages/pie-toolbox/src/code/editable-html/plugins/index.jsx
+++ b/packages/pie-toolbox/src/code/editable-html/plugins/index.jsx
@@ -245,7 +245,7 @@ export const buildPlugins = (activePlugins, customPlugins, opts) => {
     opts.responseArea && opts.responseArea.type && RespAreaPlugin(opts.responseArea, compact([mathPlugin]));
   const languageCharactersPlugins = (opts?.languageCharacters || []).map((config) => CharactersPlugin(config));
 
-  const tablePlugins = [imagePlugin, mathPlugin, ...languageCharactersPlugins];
+  const tablePlugins = [imagePlugin, mathPlugin, respAreaPlugin, ...languageCharactersPlugins];
 
   if (opts.responseArea && opts.responseArea.type === 'math-templated') {
     tablePlugins.push(respAreaPlugin);


### PR DESCRIPTION
https://illuminate.atlassian.net/browse/PD-3996

Resolved the issue in drag-in-the-blank, explicit-constructed-response, and inline-dropdown item types where the "+ Response Area" button did not appear when the cursor was positioned in a table.

The issue was introduced in @pie-lib/pie-toolbox@1.17.4.