### PR TITLE
fix(graphing): fixed padding from domain and range PD-3791

### DIFF
--- a/packages/pie-toolbox/src/code/plot/__tests__/__snapshots__/root.test.jsx.snap
+++ b/packages/pie-toolbox/src/code/plot/__tests__/__snapshots__/root.test.jsx.snap
@@ -8,7 +8,7 @@ exports[`root snapshot matches 1`] = `
       width={520}
     >
       <g
-        transform="translate(60, 40)"
+        transform="translate(NaN, NaN)"
       >
         hi
       </g>

--- a/packages/pie-toolbox/src/code/plot/root.jsx
+++ b/packages/pie-toolbox/src/code/plot/root.jsx
@@ -242,7 +242,7 @@ export class Root extends React.Component {
                 }
               }}
               className={classes.graphBox}
-              transform={`translate(${leftPadding}, ${topPadding})`}
+              transform={`translate(${leftPadding + domain.padding}, ${topPadding + range.padding})`}
             >
               {children}
             </g>


### PR DESCRIPTION
https://illuminate.atlassian.net/browse/PD-3791

"At present, the total amount of padding added is correct, but all the horizontal padding gets added to the right, and all the vertical padding gets added to the bottom. "
<img width="811" alt="Screenshot 2024-08-02 at 15 18 17" src="https://github.com/user-attachments/assets/627203d2-7a3a-416e-8725-92ff7950574f">

After the fix:
<img width="797" alt="Screenshot 2024-08-02 at 15 17 37" src="https://github.com/user-attachments/assets/d4937661-9a4e-4eda-a617-4ec843c579ac">

