### PR TITLE
fix(editable-html): Improve handling of onBlur to prevent input value reset when using special character keypads PD-4021

### DIFF
--- a/packages/pie-toolbox/src/code/editable-html/editor.jsx
+++ b/packages/pie-toolbox/src/code/editable-html/editor.jsx
@@ -605,6 +605,11 @@ export class Editor extends React.Component {
     // Check if relatedTarget is a done button
     const isRawDoneButton = relatedTarget?.closest('button[class*="RawDoneButton"]');
 
+    // Skip onBlur handling if relatedTarget is a button from the KeyPad characters
+    const isKeyPadCharacterButton = relatedTarget?.className.includes('KeyPad-character');
+
+    this.skipBlurHandling = isKeyPadCharacterButton ? true : false;
+
     if (toolbarElement && !isRawDoneButton) {
       this.setState({
         focusToolbar: true,
@@ -616,10 +621,12 @@ export class Editor extends React.Component {
     log('[onBlur] node: ', node);
 
     return new Promise((resolve) => {
-      this.setState(
-        { preBlurValue: this.state.value, focusedNode: !node ? null : node },
-        this.handleBlur.bind(this, resolve),
-      );
+      if (!this.skipBlurHandling) {
+        this.setState(
+          { preBlurValue: this.state.value, focusedNode: !node ? null : node },
+          this.handleBlur.bind(this, resolve),
+        );
+      }
       this.props.onBlur(event);
     });
   };


### PR DESCRIPTION
https://illuminate.atlassian.net/browse/PD-4021

- Introduced a `skipBlurHandling` flag to conditionally bypass onBlur logic when interacting with Spanish or special character keypads in the extended-text-entry component.
- Ensures that input values are retained correctly when special characters are inserted, without causing side effects such as duplicate onChange calls.
- Provides a solution to the issue introduced in version @pie-element/extended-text-entry@10.13.0 related to annotation rendering and keypad interaction.