### PR TITLE
fix(editable-html): Add accessible aria-label to extended-text-entry, response-area editor for improved accessibility PD-2451

### DIFF
--- a/packages/pie-toolbox/src/code/editable-html/editor.jsx
+++ b/packages/pie-toolbox/src/code/editable-html/editor.jsx
@@ -1001,86 +1001,78 @@ export class Editor extends React.Component {
       },
       className,
     );
-    const isResponseAreaEditor = names.includes('response-area-editor');
 
     return (
-      <>
-        {isResponseAreaEditor && (
-          <label htmlFor={`editor-${value?.document?.key}`} className={classes.srOnly}>
-            Answer:
-          </label>
-        )}
-        <div
-          ref={(ref) => (this.wrapperRef = ref)}
-          style={{ width: sizeStyle.width }}
-          className={names}
-          id={`editor-${value?.document?.key}`}
-        >
-          {scheduled && <div className={classes.uploading}>Uploading image and then saving...</div>}
-          <SlateEditor
-            plugins={this.plugins}
-            innerRef={(r) => {
-              if (r) {
-                this.slateEditor = r;
-              }
-            }}
-            ref={(r) => (this.editor = r && this.props.editorRef(r))}
-            toolbarRef={(r) => {
-              if (r) {
-                this.toolbarRef = r;
-              }
-            }}
-            doneButtonRef={(r) => {
-              if (r) {
-                this.doneButtonRef = r;
-              }
-            }}
-            value={value}
-            focusToolbar={this.state.focusToolbar}
-            onToolbarFocus={this.handleToolbarFocus}
-            onToolbarBlur={this.handleToolbarBlur}
-            focus={this.focus}
-            onKeyDown={onKeyDown}
-            onChange={this.onChange}
-            getFocusedValue={this.getFocusedValue}
-            onBlur={this.onBlur}
-            onDrop={(event, editor) => this.onDropPaste(event, editor, true)}
-            onPaste={(event, editor) => this.onDropPaste(event, editor)}
-            onFocus={this.onFocus}
-            onEditingDone={this.onEditingDone}
-            focusedNode={focusedNode}
-            normalize={this.normalize}
-            readOnly={disabled}
-            spellCheck={spellCheck}
-            autoCorrect={spellCheck}
-            className={classNames(
-              {
-                [classes.noPadding]: toolbarOpts && toolbarOpts.noBorder,
-              },
-              classes.slateEditor,
-            )}
-            style={{
-              minHeight: sizeStyle.minHeight,
-              height: sizeStyle.height,
-              maxHeight: sizeStyle.maxHeight,
-            }}
-            pluginProps={otherPluginProps}
-            toolbarOpts={toolbarOpts}
-            placeholder={placeholder}
-            renderPlaceholder={this.renderPlaceholder}
-            onDataChange={this.changeData}
-          />
-          <AlertDialog
-            open={dialog.open}
-            title={dialog.title}
-            text={dialog.text}
-            onClose={dialog.onClose}
-            onConfirm={dialog.onConfirm}
-            onConfirmText={dialog.onConfirmText}
-            onCloseText={dialog.onCloseText}
-          />
-        </div>
-      </>
+      <div
+        ref={(ref) => (this.wrapperRef = ref)}
+        style={{ width: sizeStyle.width }}
+        className={names}
+        id={`editor-${value?.document?.key}`}
+      >
+        {scheduled && <div className={classes.uploading}>Uploading image and then saving...</div>}
+        <SlateEditor
+          plugins={this.plugins}
+          innerRef={(r) => {
+            if (r) {
+              this.slateEditor = r;
+            }
+          }}
+          ref={(r) => (this.editor = r && this.props.editorRef(r))}
+          toolbarRef={(r) => {
+            if (r) {
+              this.toolbarRef = r;
+            }
+          }}
+          doneButtonRef={(r) => {
+            if (r) {
+              this.doneButtonRef = r;
+            }
+          }}
+          value={value}
+          focusToolbar={this.state.focusToolbar}
+          onToolbarFocus={this.handleToolbarFocus}
+          onToolbarBlur={this.handleToolbarBlur}
+          focus={this.focus}
+          onKeyDown={onKeyDown}
+          onChange={this.onChange}
+          getFocusedValue={this.getFocusedValue}
+          onBlur={this.onBlur}
+          onDrop={(event, editor) => this.onDropPaste(event, editor, true)}
+          onPaste={(event, editor) => this.onDropPaste(event, editor)}
+          onFocus={this.onFocus}
+          onEditingDone={this.onEditingDone}
+          focusedNode={focusedNode}
+          normalize={this.normalize}
+          readOnly={disabled}
+          spellCheck={spellCheck}
+          autoCorrect={spellCheck}
+          className={classNames(
+            {
+              [classes.noPadding]: toolbarOpts && toolbarOpts.noBorder,
+            },
+            classes.slateEditor,
+          )}
+          style={{
+            minHeight: sizeStyle.minHeight,
+            height: sizeStyle.height,
+            maxHeight: sizeStyle.maxHeight,
+          }}
+          pluginProps={otherPluginProps}
+          toolbarOpts={toolbarOpts}
+          placeholder={placeholder}
+          renderPlaceholder={this.renderPlaceholder}
+          onDataChange={this.changeData}
+        />
+        <AlertDialog
+          open={dialog.open}
+          title={dialog.title}
+          text={dialog.text}
+          onClose={dialog.onClose}
+          onConfirm={dialog.onConfirm}
+          onConfirmText={dialog.onConfirmText}
+          onCloseText={dialog.onCloseText}
+        />
+      </div>
     );
   }
 }
@@ -1137,16 +1129,6 @@ const styles = {
     marginTop: '6px',
     padding: '20px',
     backgroundColor: 'rgba(0,0,0,0.06)',
-  },
-  srOnly: {
-    border: 0,
-    clip: 'rect(0, 0, 0, 0)',
-    height: '1px',
-    margin: '-1px',
-    overflow: 'hidden',
-    padding: 0,
-    position: 'absolute',
-    width: '1px',
   },
 };
 

--- a/packages/pie-toolbox/src/code/editable-html/editor.jsx
+++ b/packages/pie-toolbox/src/code/editable-html/editor.jsx
@@ -388,6 +388,16 @@ export class Editor extends React.Component {
 
     window.addEventListener('resize', this.onResize);
 
+    const isResponseAreaEditor = this.props.className?.includes('response-area-editor');
+
+    if (isResponseAreaEditor && this.editor) {
+      const responseAreaEditor = document.querySelector(`[data-key="${this.editor.value.document.key}"]`);
+
+      if (responseAreaEditor) {
+        responseAreaEditor.setAttribute('aria-label', 'Answer');
+      }
+    }
+
     if (this.editor && this.props.autoFocus) {
       Promise.resolve().then(() => {
         if (this.editor) {


### PR DESCRIPTION
https://illuminate.atlassian.net/browse/PD-2451?focusedCommentId=1511565

**Revert**: The initial changes introduced by feat/PD-2450 were reverted as they did not correctly apply the label, resulting in issues with screen reader recognition.

**Resolution**: The aria-label was correctly added using document.querySelector to target the correct DOM node, ensuring that the label is recognized by screen readers. This approach effectively meets the accessibility requirements for the response-area-editor.