### PR TITLE
fix(editable-html): Fix cursor focus after typing special charactersor using the Spanish keypad & issue where focus moved to the start of input after interacting with the 'Done' button PD-4210

### DIFF
--- a/packages/pie-toolbox/src/code/editable-html/__tests__/editor.test.jsx
+++ b/packages/pie-toolbox/src/code/editable-html/__tests__/editor.test.jsx
@@ -92,6 +92,7 @@ test('onFocus changes focus if related target is not a button from language keyp
 
   const change = {
     focus: jest.fn(),
+    moveToEndOfBlock: jest.fn(),
   };
 
   await wrapper.instance().onFocus(event, change);

--- a/packages/pie-toolbox/src/code/editable-html/editor.jsx
+++ b/packages/pie-toolbox/src/code/editable-html/editor.jsx
@@ -731,6 +731,7 @@ export class Editor extends React.Component {
       const shouldFocusEditor = !isKeypadInteractionActive && !isTouchDevice;
 
       if (shouldFocusEditor) {
+        change?.moveToEndOfBlock();
         change?.focus();
       }
 


### PR DESCRIPTION
https://illuminate.atlassian.net/browse/PD-4210

I've resolved the issue where, after typing Spanish or special characters in the editor, the focus would move to the beginning of the input field. The solution involved using change.moveToEndOfBlock() to ensure the cursor remains at the end. This approach also maintains consistency with prior accessibility enhancements. The issue was more complex, as it also involved the cursor moving to the beginning after interacting with the 'Done' button and returning to the editor. In earlier versions, the focus was not retained in the editor after clicking 'Done' on the Spanish keypad  which is now resolved.