### PR TITLE
fix: removed code that messes up enter and caret in the editor [PD-4361]

### DIFF
--- a/packages/pie-toolbox/src/code/editable-html/editor.jsx
+++ b/packages/pie-toolbox/src/code/editable-html/editor.jsx
@@ -1088,8 +1088,6 @@ export class Editor extends React.Component {
             minHeight: sizeStyle.minHeight,
             height: sizeStyle.height,
             maxHeight: sizeStyle.maxHeight,
-            display: 'flex',
-            alignItems: 'center',
           }}
           pluginProps={otherPluginProps}
           toolbarOpts={toolbarOpts}


### PR DESCRIPTION
fix: removed code that messes up enter and caret in the editor [PD-4361]