### PR TITLE
Fix(ditb) adjust width for longer text-based answer choices PD-4394

### DIFF
--- a/packages/pie-toolbox/src/code/mask-markup/components/__tests__/blank.test.js
+++ b/packages/pie-toolbox/src/code/mask-markup/components/__tests__/blank.test.js
@@ -58,6 +58,7 @@ describe('Blank', () => {
 
   describe('updateDimensions', () => {
     let span;
+    let rootRef;
 
     const setSpanDimensions = (height, width) => {
       Object.defineProperty(span, 'offsetHeight', { value: height, configurable: true });
@@ -69,7 +70,10 @@ describe('Blank', () => {
       instance = wrapper.instance();
 
       span = document.createElement('span');
+      rootRef = document.createElement('span'); // rootRef should be a span or div in the real component
+
       instance.spanRef = span;
+      instance.rootRef = rootRef; // Attach rootRef
 
       Object.defineProperty(span, 'offsetHeight', { value: 0, configurable: true });
       Object.defineProperty(span, 'offsetWidth', { value: 0, configurable: true });

--- a/packages/pie-toolbox/src/code/mask-markup/components/__tests__/blank.test.js
+++ b/packages/pie-toolbox/src/code/mask-markup/components/__tests__/blank.test.js
@@ -70,10 +70,10 @@ describe('Blank', () => {
       instance = wrapper.instance();
 
       span = document.createElement('span');
-      rootRef = document.createElement('span'); // rootRef should be a span or div in the real component
+      rootRef = document.createElement('span');
 
       instance.spanRef = span;
-      instance.rootRef = rootRef; // Attach rootRef
+      instance.rootRef = rootRef;
 
       Object.defineProperty(span, 'offsetHeight', { value: 0, configurable: true });
       Object.defineProperty(span, 'offsetWidth', { value: 0, configurable: true });

--- a/packages/pie-toolbox/src/code/mask-markup/components/__tests__/blank.test.js
+++ b/packages/pie-toolbox/src/code/mask-markup/components/__tests__/blank.test.js
@@ -100,7 +100,7 @@ describe('Blank', () => {
       instance.updateDimensions();
 
       expect(instance.state).toEqual({
-        width: 0,
+        width: 54, // with padding it does exceed (30 + 24 > 50) so it's updating
         height: 0,
       });
     });

--- a/packages/pie-toolbox/src/code/mask-markup/components/blank.jsx
+++ b/packages/pie-toolbox/src/code/mask-markup/components/blank.jsx
@@ -98,13 +98,13 @@ export class BlankContent extends React.Component {
   }
 
   updateDimensions() {
-    if(this.spanRef) {
+    if(this.spanRef && this.rootRef) {
       // Temporarily set rootRef width to 'auto' for natural measurement
       this.rootRef.style.width = 'auto';
 
       // Get the natural dimensions of the content
-      const width = this.spanRef?.offsetWidth || 0;
-      const height = this.spanRef?.offsetHeight || 0;
+      const width = this.spanRef.offsetWidth || 0;
+      const height = this.spanRef.offsetHeight || 0;
 
       const widthWithPadding = width + 24;  // 12px padding on each side
 
@@ -113,9 +113,9 @@ export class BlankContent extends React.Component {
 
       const adjustedWidth = widthWithPadding <= responseAreaWidth ? responseAreaWidth : widthWithPadding;
 
-      if (height > responseAreaHeight || width > responseAreaWidth) {
+      if (height > responseAreaHeight || adjustedWidth > responseAreaWidth) {
         this.setState((prevState) => ({
-          width: width > responseAreaWidth ? widthWithPadding : prevState.width,
+          width: adjustedWidth > responseAreaWidth ? widthWithPadding : prevState.width,
           height: height > responseAreaHeight ? height : prevState.height,
         }));
       }
@@ -137,17 +137,21 @@ export class BlankContent extends React.Component {
   };
 
   getRootDimensions() {
+    // Handle potential NaN or undefined for height and width
+    const responseAreaWidth = !isNaN(parseFloat(this.props.emptyResponseAreaWidth)) ? parseFloat(this.props.emptyResponseAreaWidth) : 0;
+    const responseAreaHeight = !isNaN(parseFloat(this.props.emptyResponseAreaHeight)) ? parseFloat(this.props.emptyResponseAreaHeight) : 0;
+
     const rootStyle = {
-      height: this.state.height || this.props.emptyResponseAreaHeight,
-      width: this.state.width || this.props.emptyResponseAreaWidth,
+      height: this.state.height || responseAreaHeight,
+      width: this.state.width || responseAreaWidth,
     };
 
     // add minWidth, minHeight if width and height are not defined
     // minWidth, minHeight will be also in model in the future
     return {
       ...rootStyle,
-      ...(this.props.emptyResponseAreaWidth ? {} : { minWidth: 90 }),
-      ...(this.props.emptyResponseAreaHeight ? {} : { minHeight: 32 }),
+      ...(responseAreaWidth ? {} : { minWidth: 90 }),
+      ...(responseAreaHeight ? {} : { minHeight: 32 }),
     };
   }
 

--- a/packages/pie-toolbox/src/code/mask-markup/components/blank.jsx
+++ b/packages/pie-toolbox/src/code/mask-markup/components/blank.jsx
@@ -112,15 +112,15 @@ export class BlankContent extends React.Component {
       const responseAreaHeight = parseFloat(this.props.emptyResponseAreaHeight) || 0;
 
       const adjustedWidth = widthWithPadding <= responseAreaWidth ? responseAreaWidth : widthWithPadding;
+      const adjustedHeight = height <= responseAreaHeight ? responseAreaHeight : height;
 
-      if (height > responseAreaHeight || adjustedWidth > responseAreaWidth) {
-        this.setState((prevState) => ({
-          width: adjustedWidth > responseAreaWidth ? widthWithPadding : prevState.width,
-          height: height > responseAreaHeight ? height : prevState.height,
-        }));
-      }
+      this.setState((prevState) => ({
+        width: adjustedWidth > responseAreaWidth ? adjustedWidth : prevState.width,
+        height: adjustedHeight > responseAreaHeight ? adjustedHeight : prevState.height,
+      }));
 
       this.rootRef.style.width = `${adjustedWidth}px`;
+      this.rootRef.style.height = `${adjustedHeight}px`;
     }
   }
 

--- a/packages/pie-toolbox/src/code/mask-markup/components/blank.jsx
+++ b/packages/pie-toolbox/src/code/mask-markup/components/blank.jsx
@@ -98,19 +98,29 @@ export class BlankContent extends React.Component {
   }
 
   updateDimensions() {
-    const height = this.spanRef?.offsetHeight || 0;
-    const width = this.spanRef?.offsetWidth || 0;
+    if(this.spanRef) {
+      // Temporarily set rootRef width to 'auto' for natural measurement
+      this.rootRef.style.width = 'auto';
 
-    // force our computing to work if our client set the emptyResponseAreaHeight
-    // both to '40px' or 40
-    const responseAreaHeight = parseFloat(this.props.emptyResponseAreaHeight) || 0;
-    const responseAreaWidth = parseFloat(this.props.emptyResponseAreaWidth) || 0;
-    if (height > responseAreaHeight || width > responseAreaWidth) {
-      this.setState((prevState) => ({
-        // Add 24px padding (12px on each side) to ensure spacing, as width is calculated just to fit exactly to the content
-        width: width > responseAreaWidth ? width + 24 : prevState.width,
-        height: height > responseAreaHeight ? height : prevState.height,
-      }));
+      // Get the natural dimensions of the content
+      const width = this.spanRef?.offsetWidth || 0;
+      const height = this.spanRef?.offsetHeight || 0;
+
+      const widthWithPadding = width + 24;  // 12px padding on each side
+
+      const responseAreaWidth = parseFloat(this.props.emptyResponseAreaWidth) || 0;
+      const responseAreaHeight = parseFloat(this.props.emptyResponseAreaHeight) || 0;
+
+      const adjustedWidth = widthWithPadding <= responseAreaWidth ? responseAreaWidth : widthWithPadding;
+
+      if (height > responseAreaHeight || width > responseAreaWidth) {
+        this.setState((prevState) => ({
+          width: width > responseAreaWidth ? widthWithPadding : prevState.width,
+          height: height > responseAreaHeight ? height : prevState.height,
+        }));
+      }
+
+      this.rootRef.style.width = `${adjustedWidth}px`;
     }
   }
 

--- a/packages/pie-toolbox/src/code/mask-markup/components/blank.jsx
+++ b/packages/pie-toolbox/src/code/mask-markup/components/blank.jsx
@@ -137,7 +137,7 @@ export class BlankContent extends React.Component {
   };
 
   getRootDimensions() {
-    // Handle potential NaN or undefined for height and width
+    // Handle potential non-numeric values
     const responseAreaWidth = !isNaN(parseFloat(this.props.emptyResponseAreaWidth)) ? parseFloat(this.props.emptyResponseAreaWidth) : 0;
     const responseAreaHeight = !isNaN(parseFloat(this.props.emptyResponseAreaHeight)) ? parseFloat(this.props.emptyResponseAreaHeight) : 0;
 


### PR DESCRIPTION
https://illuminate.atlassian.net/browse/PD-4394
The change was made to ensure the content inside the span element has a more natural, non-narrow width. By temporarily setting the rootRef width to 'auto', it allows the width to be calculated based on the content.