### PR TITLE
feat(drag): for ICA choice pool, add isVertical and minHeight props PD-4387

### DIFF
--- a/packages/pie-toolbox/src/code/drag/__tests__/__snapshots__/placeholder.test.jsx.snap
+++ b/packages/pie-toolbox/src/code/drag/__tests__/__snapshots__/placeholder.test.jsx.snap
@@ -3,7 +3,11 @@
 exports[`placeholder snapshot className 1`] = `
 <div
   className="placeholder bar"
-  style={Object {}}
+  style={
+    Object {
+      "minHeight": undefined,
+    }
+  }
 >
    Foo 
 </div>
@@ -12,7 +16,11 @@ exports[`placeholder snapshot className 1`] = `
 exports[`placeholder snapshot disabled: true 1`] = `
 <div
   className="placeholder disabled"
-  style={Object {}}
+  style={
+    Object {
+      "minHeight": undefined,
+    }
+  }
 >
    Foo 
 </div>
@@ -21,7 +29,11 @@ exports[`placeholder snapshot disabled: true 1`] = `
 exports[`placeholder snapshot isOver: true 1`] = `
 <div
   className="placeholder over"
-  style={Object {}}
+  style={
+    Object {
+      "minHeight": undefined,
+    }
+  }
 >
    Foo 
 </div>
@@ -30,7 +42,11 @@ exports[`placeholder snapshot isOver: true 1`] = `
 exports[`placeholder snapshot reqular 1`] = `
 <div
   className="placeholder"
-  style={Object {}}
+  style={
+    Object {
+      "minHeight": undefined,
+    }
+  }
 >
    Foo 
 </div>
@@ -43,6 +59,7 @@ exports[`placeholder snapshot specific grid rowsRepeatValue 1`] = `
     Object {
       "gridTemplateColumns": "repeat(1, 1fr)",
       "gridTemplateRows": "repeat(2, min-content)",
+      "minHeight": undefined,
     }
   }
 >

--- a/packages/pie-toolbox/src/code/drag/droppable-placeholder.jsx
+++ b/packages/pie-toolbox/src/code/drag/droppable-placeholder.jsx
@@ -13,14 +13,23 @@ export class DroppablePlaceholder extends React.Component {
     isOver: PropTypes.bool,
     children: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.node), PropTypes.node]).isRequired,
     disabled: PropTypes.bool,
+    isVerticalPool: PropTypes.bool,
+    minHeight: PropTypes.number,
   };
 
   render() {
-    const { children, connectDropTarget, isOver, disabled, classes } = this.props;
+    const { children, connectDropTarget, isOver, disabled, classes, isVerticalPool, minHeight } = this.props;
 
     return connectDropTarget(
       <div style={preventInteractionStyle}>
-        <PlaceHolder disabled={disabled} isOver={isOver} choiceBoard={true} className={classes}>
+        <PlaceHolder
+          disabled={disabled}
+          isOver={isOver}
+          choiceBoard={true}
+          className={classes}
+          isVerticalPool={isVerticalPool}
+          minHeight={minHeight}
+        >
           {children}
         </PlaceHolder>
       </div>,

--- a/packages/pie-toolbox/src/code/drag/placeholder.jsx
+++ b/packages/pie-toolbox/src/code/drag/placeholder.jsx
@@ -6,13 +6,26 @@ import grey from '@material-ui/core/colors/grey';
 import { color } from '../render-ui';
 
 export const PlaceHolder = (props) => {
-  const { children, classes, className, isOver, type, grid, disabled, choiceBoard, isCategorize } = props;
+  const {
+    children,
+    classes,
+    className,
+    isOver,
+    type,
+    grid,
+    disabled,
+    choiceBoard,
+    isCategorize,
+    isVerticalPool,
+    minHeight,
+  } = props;
+
   const names = classNames(
-      classes.placeholder,
-      disabled && classes.disabled,
-      isOver && classes.over,
-      classes[type],
-      className,
+    classes.placeholder,
+    disabled && classes.disabled,
+    isOver && classes.over,
+    classes[type],
+    className,
   );
 
   const style = {};
@@ -39,15 +52,16 @@ export const PlaceHolder = (props) => {
   const boardStyle = isCategorize ? classes.categorizeBoard : classes.board;
 
   return (
-      <div
-          style={style}
-          className={classNames(
-              classes.noSelectStyles,
-              choiceBoard ? boardStyle : names
-          )}
-      >
-        {children}
-      </div>
+    <div
+      style={{ ...style, minHeight: minHeight }}
+      className={classNames(
+        classes.noSelectStyles,
+        choiceBoard ? boardStyle : names,
+        isVerticalPool && classes.verticalPool,
+      )}
+    >
+      {children}
+    </div>
   );
 };
 
@@ -67,6 +81,8 @@ PlaceHolder.propTypes = {
   type: PropTypes.string,
   disabled: PropTypes.bool,
   isCategorize: PropTypes.bool,
+  isVerticalPool: PropTypes.bool,
+  minHeight: PropTypes.number,
 };
 
 const styles = (theme) => ({
@@ -119,6 +135,10 @@ const styles = (theme) => ({
     overflow: 'hidden',
     touchAction: 'none',
     backgroundColor: color.backgroundDark(),
+  },
+  verticalPool: {
+    display: 'flex',
+    flexFlow: 'column wrap',
   },
 });
 


### PR DESCRIPTION
The `isVertical` property makes sure that the pool is displayed in a flex column way for left or right arrangement of the choice pool in ICA. 
The `minHeight` property is used for this vertical display, to "stretch" the pool.
https://illuminate.atlassian.net/browse/PD-4387 
example:
<img width="857" alt="image" src="https://github.com/user-attachments/assets/95b407d5-e77a-4bff-8e41-80b2d16d3431">
