### PR TITLE
fix(blank drag-in-the-blank): Remove default <p> margins for consistent spacing across wrapped content in blank drag-in-the-blank for optimal space PD-4394

### DIFF
--- a/packages/pie-toolbox/src/code/mask-markup/components/__tests__/blank.test.js
+++ b/packages/pie-toolbox/src/code/mask-markup/components/__tests__/blank.test.js
@@ -86,7 +86,7 @@ describe('Blank', () => {
 
       expect(instance.state).toEqual({
         width: 74,
-        height: 50,
+        height: 74,
       });
     });
 
@@ -100,8 +100,8 @@ describe('Blank', () => {
       instance.updateDimensions();
 
       expect(instance.state).toEqual({
-        width: 54, // with padding it does exceed (30 + 24 > 50) so it's updating
-        height: 0,
+        width: 54,  // with padding it does exceed (30 + 24 > 50) so it's updating
+        height: 54, // with padding it does exceed (30 + 24 > 50) so it's updating
       });
     });
 
@@ -116,7 +116,7 @@ describe('Blank', () => {
 
       expect(instance.state).toEqual({
         width: 74,
-        height: 50,
+        height: 74,
       });
     });
   });

--- a/packages/pie-toolbox/src/code/mask-markup/components/blank.jsx
+++ b/packages/pie-toolbox/src/code/mask-markup/components/blank.jsx
@@ -38,6 +38,13 @@ const useStyles = withStyles(() => ({
       display: 'block',
       padding: '2px 0',
     },
+    // Remove default <p> margins to ensure consistent spacing across all wrapped content (p, span, div, math)
+    // Padding for top and bottom will instead be controlled by the container for consistent layout
+    // Ensures consistent behavior with pie-api-browser, where marginTop is already removed by a Bootstrap stylesheet
+    '& p': {
+      marginTop: '0',
+      marginBottom: '0'
+    }
   },
   hidden: {
     color: 'transparent',
@@ -107,12 +114,13 @@ export class BlankContent extends React.Component {
       const height = this.spanRef.offsetHeight || 0;
 
       const widthWithPadding = width + 24;  // 12px padding on each side
+      const heightWithPadding = height + 24; // 12px padding on top and bottom
 
       const responseAreaWidth = parseFloat(this.props.emptyResponseAreaWidth) || 0;
       const responseAreaHeight = parseFloat(this.props.emptyResponseAreaHeight) || 0;
 
       const adjustedWidth = widthWithPadding <= responseAreaWidth ? responseAreaWidth : widthWithPadding;
-      const adjustedHeight = height <= responseAreaHeight ? responseAreaHeight : height;
+      const adjustedHeight = heightWithPadding <= responseAreaHeight ? responseAreaHeight : heightWithPadding;
 
       this.setState((prevState) => ({
         width: adjustedWidth > responseAreaWidth ? adjustedWidth : prevState.width,


### PR DESCRIPTION
https://illuminate.atlassian.net/browse/PD-4394
Issue: 
In Drag-in-the-Blank 6.2.2, the text of answer choices is spilling past the top and bottom borders of response areas. This issue varies in severity, with some text slightly overflowing and others significantly so.

Cause: 
The issue originates from a Bootstrap stylesheet imported in the PIE API browser, which removes default top margins from p tags. This causes the text within drag-and-drop tokens to exceed their container boundaries.

Solution:
Removed default p margins to ensure consistent spacing across all wrapped content (p, span, div, math).
Container-controlled padding for top and bottom ensures consistent layout.
This fix aligns behavior with the PIE API browser, where marginTop is already removed by the Bootstrap stylesheet.
This update resolves the text overflow issue, ensuring a uniform and visually consistent layout for all response areas.

![Screenshot 2024-12-03 at 10 49 00](https://github.com/user-attachments/assets/f1252312-56a9-4362-9f86-07e923a97c63)
