### PR TITLE
fix(render-ui, anser-toggle): avoid table to be overwritten by browse…

### DIFF
--- a/packages/pie-toolbox/src/code/correct-answer-toggle/expander.jsx
+++ b/packages/pie-toolbox/src/code/correct-answer-toggle/expander.jsx
@@ -34,14 +34,16 @@ export default withStyles(() => ({
   enter: {
     transition,
     opacity: 1,
-    height: '25px',
+    height: 'auto',
     width: 'auto',
     visibility: 'visible',
+    minHeight: '25px',
   },
   enterDone: {
-    height: '25px',
+    height: 'auto',
     visibility: 'visible',
     width: 'auto',
+    minHeight: '25px',
   },
   exit: {
     transition,

--- a/packages/pie-toolbox/src/code/correct-answer-toggle/styles.js
+++ b/packages/pie-toolbox/src/code/correct-answer-toggle/styles.js
@@ -25,8 +25,7 @@ export default {
       minWidth: '140px',
       // eslint-disable-next-line
       fontFamily: "'Roboto', sans-serif",
-      height: '25px',
-      lineHeight: '25px',
+      alignSelf: 'center',
       verticalAlign: 'middle',
       color: `var(--correct-answer-toggle-label-color,  ${color.text()})`,
       fontWeight: 'normal',

--- a/packages/pie-toolbox/src/code/render-ui/ui-layout.jsx
+++ b/packages/pie-toolbox/src/code/render-ui/ui-layout.jsx
@@ -36,7 +36,7 @@ class UiLayout extends AppendCSSRules {
   render() {
     const { children, className, classes, fontSizeFactor, ...rest } = this.props;
 
-    const finalClass = classNames(className, classes.extraCSSRules);
+    const finalClass = classNames(className, classes.extraCSSRules, classes.uiLayoutContainer);
     const restProps = omit(rest, 'extraCSSRules');
 
     return (
@@ -49,6 +49,12 @@ class UiLayout extends AppendCSSRules {
 
 const styles = {
   extraCSSRules: {},
+  // need this because some browsers set their own style on table
+  uiLayoutContainer: {
+    '& table, th, td': {
+      fontSize: 'inherit' /* Ensure table elements inherit font size */,
+    },
+  },
 };
 
 const Styled = withStyles(styles)(UiLayout);


### PR DESCRIPTION
…rs fontsize, adjust correct answer style to fit new fontsize PD-4388