### PR TITLE
fix(drag): Fix touch position handling with zoom adjustment and offset PD-4548

### DIFF
--- a/packages/pie-toolbox/src/code/drag/preview-component.jsx
+++ b/packages/pie-toolbox/src/code/drag/preview-component.jsx
@@ -99,9 +99,10 @@ const PreviewComponent = () => {
     (event) => {
       if (event.touches.length > 0) {
         const touch = event.touches[0];
+        const touchOffset = 1;
         setTouchPosition({
-          x: touch.clientX / zoomLevel,
-          y: touch.clientY / zoomLevel,
+          x: (touch.clientX + touchOffset) / zoomLevel,
+          y: (touch.clientY + touchOffset) / zoomLevel,
         });
       }
     },


### PR DESCRIPTION
https://illuminate.atlassian.net/browse/PD-4548

The problem: 
When dragging and dropping a token, the droppable area initially turns grey as expected. However, if the token is slightly moved while still within the droppable zone, the area loses focus and reverts to its default state. This behavior prevents the token from being dropped, even though it visually appears to be inside the droppable zone.
A screen recording demonstrating the issue is available in the task's comment section.
The fix: 
`TouchOffset` was introduced as a simple adjustment to correct the calculated touch position during drag-and-drop interactions on touch devices.