### PR TITLE
fix(ECR): enhance valueToSize in editor to handle calc expressions and ch units PD-4618

### DIFF
--- a/packages/pie-toolbox/src/code/editable-html/__tests__/editor.test.jsx
+++ b/packages/pie-toolbox/src/code/editable-html/__tests__/editor.test.jsx
@@ -224,7 +224,7 @@ describe('buildSizeStyle', () => {
     );
   };
 
-  it('builds width', () => {
+  it('builds width with px', () => {
     const w = wrapper({ width: 100 });
     expect(w.instance().buildSizeStyle()).toEqual({
       width: '100px',
@@ -274,10 +274,20 @@ describe('buildSizeStyle', () => {
     });
   });
 
-  it('builds width', () => {
-    const w = wrapper({ width: 100 });
+  it('builds width with calc()', () => {
+    const w = wrapper({ width: 'calc(10ch + 42px)' });
     expect(w.instance().buildSizeStyle()).toEqual({
-      width: '100px',
+      width: 'calc(10ch + 42px)',
+      height: undefined,
+      minHeight: undefined,
+      maxHeight: undefined,
+    });
+  });
+
+  it('builds width with ch', () => {
+    const w = wrapper({ width: '9ch' });
+    expect(w.instance().buildSizeStyle()).toEqual({
+      width: '9ch',
       height: undefined,
       minHeight: undefined,
       maxHeight: undefined,

--- a/packages/pie-toolbox/src/code/editable-html/editor.jsx
+++ b/packages/pie-toolbox/src/code/editable-html/editor.jsx
@@ -839,11 +839,12 @@ export class Editor extends React.Component {
     if (!v) {
       return;
     }
+    const calcRegex = /^calc\((.*)\)$/;
 
     if (typeof v === 'string') {
       if (v.endsWith('%')) {
         return undefined;
-      } else if (v.endsWith('px') || v.endsWith('vh') || v.endsWith('vw')) {
+      } else if (v.endsWith('px') || v.endsWith('vh') || v.endsWith('vw') || v.endsWith('ch') || v.match(calcRegex)) {
         return v;
       } else {
         const value = parseInt(v, 10);

--- a/packages/pie-toolbox/src/code/mask-markup/constructed-response.jsx
+++ b/packages/pie-toolbox/src/code/mask-markup/constructed-response.jsx
@@ -21,7 +21,6 @@ const styles = (theme) => ({
   }
 });
 
-// eslint-disable-next-line react/display-name
 const MaskedInput = (props) => (node, data) => {
   const { adjustedLimit, disabled, feedback, showCorrectAnswer, maxLength, spellCheck, classes, pluginProps, onChange } = props;
   const dataset = node.data?.dataset || {};
@@ -41,6 +40,13 @@ const MaskedInput = (props) => (node, data) => {
       onChange(updatedValue);
     };
 
+    const handleKeyDown = (event) => {
+        // the keyCode value for the Enter/Return key is 13
+        if (event.key === 'Enter' || event.keyCode === 13) {
+            return false;
+        }
+    };
+
     return (
         <EditableHtml
             id={dataset.id}
@@ -54,7 +60,8 @@ const MaskedInput = (props) => (node, data) => {
             pluginProps={pluginProps}
             languageCharactersProps={[{ language: 'spanish' }]}
             spellCheck={spellCheck}
-            width={width * 25}
+            width={`calc(${width}ch + 42px)`} // added 42px for left and right padding of editable-html
+            onKeyDown={handleKeyDown}
             toolbarOpts={{
               minWidth: 'auto',
               noBorder: true,


### PR DESCRIPTION
https://illuminate.atlassian.net/browse/PD-4618

1. In ECR response areas, response areas must be wide enough to accommodate the specified number of characters - for that I've adjusted editor to support calc expressions and ch units.
2. In ECR Gather, the Return/Enter key should be ignored. 

<img width="765" alt="Screenshot 2024-12-12 at 13 17 41" src="https://github.com/user-attachments/assets/167d2412-1d4f-4031-b129-5fb8fdab931d" />
