### PR TITLE
fix(mask-markup): add styling from prompt tables to response area tab…

### DIFF
--- a/packages/pie-toolbox/src/code/mask-markup/mask.jsx
+++ b/packages/pie-toolbox/src/code/mask-markup/mask.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import get from 'lodash/get';
 import { withStyles } from '@material-ui/core/styles';
 import { MARK_TAGS } from './serialization';
+import cx from 'classnames';
 
 const Paragraph = withStyles((theme) => ({
   para: {
@@ -110,7 +111,17 @@ const MaskContainer = withStyles(() => ({
   main: {
     display: 'initial',
   },
-}))((props) => <div className={props.classes.main}>{props.children}</div>);
+  tableStyle: {
+    '&:not(.MathJax) table': {
+      borderCollapse: 'collapse',
+    },
+    // align table content to left as per STAR requirement PD-3687
+    '&:not(.MathJax) table td, &:not(.MathJax) table th': {
+      padding: '.6em 1em',
+      textAlign: 'left',
+    },
+  },
+}))((props) => <div className={cx(props.classes.main, props.classes.tableStyle)}>{props.children}</div>);
 
 /**
  * Renders a layout that uses the slate.js Value model structure.


### PR DESCRIPTION
…les PD-4521
https://illuminate.atlassian.net/browse/PD-4521

before: prompt vs response area (in inline-dropdown, explicit-constructed-response and drag-in-the-blank)
![image](https://github.com/user-attachments/assets/9e9f86f2-b111-4d5e-bfa7-b2f92fc8dfde)

after: 
![image](https://github.com/user-attachments/assets/a3a9a7dc-1fd8-48ca-b0a9-2886c96a1644)
