### PR TITLE
fix(mask-markup): use whitespace normal for chip labels PD-4607

### DIFF
--- a/packages/pie-toolbox/src/code/mask-markup/choices/choice.jsx
+++ b/packages/pie-toolbox/src/code/mask-markup/choices/choice.jsx
@@ -84,7 +84,7 @@ export const BlankContent = withStyles((theme) => ({
     paddingBottom: '12px',
   },
   chipLabel: {
-    whiteSpace: 'pre-wrap',
+    whiteSpace: 'normal',
     '& img': {
       display: 'block',
       padding: '2px 0',

--- a/packages/pie-toolbox/src/code/mask-markup/components/blank.jsx
+++ b/packages/pie-toolbox/src/code/mask-markup/components/blank.jsx
@@ -32,7 +32,7 @@ const useStyles = withStyles(() => ({
     margin: '8px',
   },
   chipLabel: {
-    whiteSpace: 'pre-wrap',
+    whiteSpace: 'normal',
     // Added for touch devices, for image content.
     // This will prevent the context menu from appearing and not allowing other interactions with the image.
     // If interactions with the image in the token will be requested we should handle only the context Menu.
@@ -46,8 +46,8 @@ const useStyles = withStyles(() => ({
     // Ensures consistent behavior with pie-api-browser, where marginTop is already removed by a Bootstrap stylesheet
     '& p': {
       marginTop: '0',
-      marginBottom: '0'
-    }
+      marginBottom: '0',
+    },
   },
   hidden: {
     color: 'transparent',
@@ -120,8 +120,7 @@ export class BlankContent extends React.Component {
       const width = this.spanRef.offsetWidth || 0;
       const height = this.spanRef.offsetHeight || 0;
 
-
-      const widthWithPadding = width + 24;  // 12px padding on each side
+      const widthWithPadding = width + 24; // 12px padding on each side
       const heightWithPadding = height + 24; // 12px padding on top and bottom
 
       const responseAreaWidth = parseFloat(this.props.emptyResponseAreaWidth) || 0;


### PR DESCRIPTION
https://illuminate.atlassian.net/browse/PD-4607
`white-space: pre-wrap` was causing issues and I did not found a reason for it. 
If we have multiple white spaces inside the chip label, the browser treats these as additional inline content that needs layout accommodation when using pre-wrap.
By changing the `white-space: pre-wrap` to `white-space: normal`,  wrapping will still happen, but only as needed based on content and container width.
I tested math content, image content and some models and it seems fine. Hopefully no DIB item needs the pre-wrap.

Item with the issue: 
Before:
<img width="983" alt="image" src="https://github.com/user-attachments/assets/61de3e16-a103-4fd1-8573-9c3e28bdf435" />

After:
<img width="978" alt="image" src="https://github.com/user-attachments/assets/223c1ef4-7648-4606-b0d1-764459b9f0e6" />

