### PR TITLE
fix(editor-and-toolbar): Changed overflowY from 'scroll' to 'auto' for dynamic scrollbar PD-4618

### DIFF
--- a/packages/pie-toolbox/src/code/editable-html/plugins/toolbar/editor-and-toolbar.jsx
+++ b/packages/pie-toolbox/src/code/editable-html/plugins/toolbar/editor-and-toolbar.jsx
@@ -149,7 +149,7 @@ const style = (theme) => ({
   editorHolder: {
     position: 'relative',
     padding: '0px',
-    overflowY: 'scroll',
+    overflowY: 'auto',
     color: color.text(),
     backgroundColor: color.background(),
     '&::before': {


### PR DESCRIPTION
Updated overflowY property from 'scroll' to 'auto' to improve scrollbar behavior. On Windows, the scrollbar was always visible, even when content didn't require scrolling, resulting in unnecessary space usage. With 'auto', the scrollbar now only appears when needed, ensuring a cleaner layout.
https://illuminate.atlassian.net/browse/PD-4618