### PR TITLE
fix(drag): use same border color ica on drag PD-4766

### DIFF
--- a/packages/pie-toolbox/src/code/drag/preview-component.jsx
+++ b/packages/pie-toolbox/src/code/drag/preview-component.jsx
@@ -19,7 +19,7 @@ const styles = {
   },
   ica: {
     backgroundColor: color.background(),
-    border: `1px solid ${color.primary()}`,
+    border: `1px solid ${color.borderDark()}`,
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'center',


### PR DESCRIPTION
https://illuminate.atlassian.net/browse/PD-4766
`color.borderDark()` is used in a style in pie-elements for ICA. For some reason on IPad, this is the style that is overwriting the pie-elements style, so I changed from `color.primary()` to `color.borderDark()` to match the one visible on web.