### PR TITLE
Fix: restore vertical layout of <p> tags in multiple-choice answer choices by setting flex-direction: column PD-4917

### DIFF
--- a/packages/pie-toolbox/src/code/render-ui/preview-prompt.jsx
+++ b/packages/pie-toolbox/src/code/render-ui/preview-prompt.jsx
@@ -223,6 +223,7 @@ const styles = (theme) => ({
   label: {
     color: `${color.text()} !important`, //'var(--choice-input-color, black)',
     display: 'flex',
+    flexDirection: 'column',
     verticalAlign: 'middle',
     cursor: 'pointer',
     '& > p': {


### PR DESCRIPTION
https://illuminate.atlassian.net/browse/PD-4917