### PR TITLE
feat(drag): fix style to be the same as chip PD-4765

### DIFF
--- a/packages/pie-toolbox/src/code/drag/preview-component.jsx
+++ b/packages/pie-toolbox/src/code/drag/preview-component.jsx
@@ -5,17 +5,20 @@ import { renderMath } from '../math-rendering';
 
 const styles = {
   maskBlank: {
-    border: '1px solid black',
-    color: 'black',
-    minWidth: '90px',
-    minHeight: '32px',
-    height: 'auto',
-    maxWidth: '374px',
-    display: 'flex',
-    padding: '4px',
+    // this style is applied only on small screens and for touch devices when dragging, for drag-in-the-blank.
+    // It is styled to be identical to the drag-in-the-blank chip
+    backgroundColor: color.white(),
+    border: `1px solid ${color.text()}`,
+    color: color.text(),
     alignItems: 'center',
-    justifyContent: 'center',
-    borderRadius: '16px',
+    display: 'inline-flex',
+    height: 'initial',
+    minHeight: '32px',
+    fontSize: 'inherit',
+    whiteSpace: 'pre-wrap',
+    maxWidth: '374px',
+    borderRadius: '3px',
+    padding: '12px',
   },
   ica: {
     backgroundColor: color.background(),


### PR DESCRIPTION
The style before was not matching the style that is applied when the choice is not dragged. It should be the same.
This is not affecting laptop, only touch devices. 
https://illuminate.atlassian.net/browse/PD-4765
Before: 
<img width="1322" alt="image" src="https://github.com/user-attachments/assets/c8663797-d450-43c2-8914-2823d0c18055" />


After: 
<img width="348" alt="image" src="https://github.com/user-attachments/assets/43e2e455-49eb-41c9-aaee-769be41d4d0d" />
