### PR TITLE
feat(math-rendering): remove mathml from tab navigation PD-4561

### DIFF
--- a/packages/pie-toolbox/src/code/math-rendering-accessible/render-math.js
+++ b/packages/pie-toolbox/src/code/math-rendering-accessible/render-math.js
@@ -153,6 +153,7 @@ const renderContentWithMathJax = (executeOn) => {
             const parsedMathMl = mathMl.replaceAll('\n', '');
 
             item.data.typesetRoot.setAttribute('data-mathml', parsedMathMl);
+            item.data.typesetRoot.setAttribute('tabindex', '-1');
           }
 
           // If the original input was a string, return the parsed MathML

--- a/packages/pie-toolbox/src/code/math-rendering/render-math.js
+++ b/packages/pie-toolbox/src/code/math-rendering/render-math.js
@@ -265,6 +265,7 @@ const bootstrap = (opts) => {
               const parsedMathMl = mathMl.replaceAll('\n', '');
 
               item.data.typesetRoot.setAttribute('data-mathml', parsedMathMl);
+              item.data.typesetRoot.setAttribute('tabindex', '-1');
             }
           }
         } catch (e) {


### PR DESCRIPTION
https://illuminate.atlassian.net/browse/PD-4561
this is not an interactive item, so we don't want tab navigation to pick it up