### PR TITLE
fix(charting): add px values for MUI svg PD-5198

### DIFF
--- a/packages/pie-toolbox/src/code/charting/axes.jsx
+++ b/packages/pie-toolbox/src/code/charting/axes.jsx
@@ -508,6 +508,8 @@ const ChartAxes = withStyles(
       borderRadius: theme.spacing.unit * 2,
       color: color.defaults.WHITE,
       fontSize: '16px',
+      width: '16px',
+      height: '16px',
       padding: '2px',
       border: `1px solid ${color.defaults.WHITE}`,
     },

--- a/packages/pie-toolbox/src/code/charting/axes.jsx
+++ b/packages/pie-toolbox/src/code/charting/axes.jsx
@@ -512,6 +512,7 @@ const ChartAxes = withStyles(
       height: '16px',
       padding: '2px',
       border: `1px solid ${color.defaults.WHITE}`,
+      boxSizing: 'unset', // to override the default border-box in IBX
     },
     incorrectIcon: {
       backgroundColor: color.incorrectWithIcon(),

--- a/packages/pie-toolbox/src/code/charting/bars/common/bars.jsx
+++ b/packages/pie-toolbox/src/code/charting/bars/common/bars.jsx
@@ -241,6 +241,8 @@ const Bar = withStyles((theme) => ({
     borderRadius: theme.spacing.unit * 2,
     color: color.defaults.WHITE,
     fontSize: '10px',
+    width: '10px',
+    height: '10px',
     padding: '2px',
     border: `1px solid ${color.defaults.WHITE}`,
   },

--- a/packages/pie-toolbox/src/code/charting/bars/common/bars.jsx
+++ b/packages/pie-toolbox/src/code/charting/bars/common/bars.jsx
@@ -245,6 +245,7 @@ const Bar = withStyles((theme) => ({
     height: '10px',
     padding: '2px',
     border: `1px solid ${color.defaults.WHITE}`,
+    boxSizing: 'unset', // to override the default border-box in IBX
   },
 }))(RawBar);
 

--- a/packages/pie-toolbox/src/code/charting/common/drag-handle.jsx
+++ b/packages/pie-toolbox/src/code/charting/common/drag-handle.jsx
@@ -130,6 +130,7 @@ export const DragHandle = withStyles((theme) => ({
     border: `4px solid ${enumColor.defaults.WHITE}`,
     width: '16px',
     height: '16px',
+    boxSizing: 'unset', // to override the default border-box in IBX
   },
 }))(RawDragHandle);
 

--- a/packages/pie-toolbox/src/code/charting/common/drag-handle.jsx
+++ b/packages/pie-toolbox/src/code/charting/common/drag-handle.jsx
@@ -128,6 +128,8 @@ export const DragHandle = withStyles((theme) => ({
     fontSize: '16px',
     padding: '2px',
     border: `4px solid ${enumColor.defaults.WHITE}`,
+    width: '16px',
+    height: '16px',
   },
 }))(RawDragHandle);
 

--- a/packages/pie-toolbox/src/code/charting/line/common/drag-handle.jsx
+++ b/packages/pie-toolbox/src/code/charting/line/common/drag-handle.jsx
@@ -81,12 +81,16 @@ export const DragHandle = withStyles((theme) => ({
     borderRadius: theme.spacing.unit * 2,
     color: color.defaults.WHITE,
     fontSize: '16px',
+    width: '16px',
+    height: '16px',
     padding: '2px',
     border: `1px solid ${color.defaults.WHITE}`,
     stroke: 'initial',
   },
   smallIcon: {
     fontSize: '10px',
+    width: '10px',
+    height: '10px',
   },
 }))(RawDragHandle);
 

--- a/packages/pie-toolbox/src/code/charting/line/common/drag-handle.jsx
+++ b/packages/pie-toolbox/src/code/charting/line/common/drag-handle.jsx
@@ -86,6 +86,7 @@ export const DragHandle = withStyles((theme) => ({
     padding: '2px',
     border: `1px solid ${color.defaults.WHITE}`,
     stroke: 'initial',
+    boxSizing: 'unset', // to override the default border-box in IBX
   },
   smallIcon: {
     fontSize: '10px',

--- a/packages/pie-toolbox/src/code/charting/plot/common/plot.jsx
+++ b/packages/pie-toolbox/src/code/charting/plot/common/plot.jsx
@@ -260,6 +260,7 @@ const Bar = withStyles((theme) => ({
     padding: '2px',
     border: `1px solid ${color.defaults.WHITE}`,
     stroke: 'initial',
+    boxSizing: 'unset', // to override the default border-box in IBX
   },
 }))(RawPlot);
 

--- a/packages/pie-toolbox/src/code/charting/plot/common/plot.jsx
+++ b/packages/pie-toolbox/src/code/charting/plot/common/plot.jsx
@@ -255,6 +255,8 @@ const Bar = withStyles((theme) => ({
     borderRadius: theme.spacing.unit * 2,
     color: color.defaults.WHITE,
     fontSize: '16px',
+    width: '16px',
+    height: '16px',
     padding: '2px',
     border: `1px solid ${color.defaults.WHITE}`,
     stroke: 'initial',


### PR DESCRIPTION
https://illuminate.atlassian.net/browse/PD-5198 
em is set to 10px in IBX and box-sizing is set to border-box, which means that width/height include content + padding + border and it's breaking the svg.
Adding "unset" reverts to content-box → width/height only include the content, not padding or borders.