### PR TITLE
fix(charting): fix box-sizing that breaks charting svg in IBX PD-5196

### DIFF
--- a/packages/pie-toolbox/src/code/plot/root.jsx
+++ b/packages/pie-toolbox/src/code/plot/root.jsx
@@ -313,6 +313,7 @@ const styles = (theme) => ({
     backgroundColor: theme.palette.common.white,
     touchAction: 'none',
     position: 'relative',
+    boxSizing: 'unset', // to override the default border-box in IBX that breaks the component width layout
   },
   wrapper: {
     display: 'flex',
@@ -365,7 +366,6 @@ const styles = (theme) => ({
     display: 'flex',
     flexDirection: 'column',
     marginRight: '6px',
-    marginLeft: '12px',
   },
   sidePixelIndicator: {
     textAlign: 'right',


### PR DESCRIPTION
https://illuminate.atlassian.net/browse/PD-5196

content-box (default) → width/height only include the content, not padding or borders. - This is what we want

border-box → width/height include content + padding + border. - This is set in IBX globally