### PR TITLE
fix(editable-html-tip-tap): adjust placeholder styling for empty para…

### DIFF
--- a/packages/editable-html-tip-tap/src/components/EditableHtml.jsx
+++ b/packages/editable-html-tip-tap/src/components/EditableHtml.jsx
@@ -361,7 +361,8 @@ const StyledEditorContent = styled(EditorContent, {
 
     '& p.is-editor-empty:first-child::before': {
       content: 'attr(data-placeholder)',
-      display: 'block',
+      float: 'left',
+      height: 0,
       color: '#9CA3AF',
       pointerEvents: 'none',
       whiteSpace: 'pre-wrap',


### PR DESCRIPTION
…graphs to prevent extra height
issue found in https://illuminate.atlassian.net/browse/PD-5594?focusedCommentId=2241072 