### PR TITLE
fix: provided the pos of the node as well in the response area toolbar callback [PD-5787]

### DIFF
--- a/packages/editable-html-tip-tap/src/components/__tests__/ExplicitConstructedResponse.test.jsx
+++ b/packages/editable-html-tip-tap/src/components/__tests__/ExplicitConstructedResponse.test.jsx
@@ -124,7 +124,7 @@ describe('ExplicitConstructedResponse', () => {
 
   it('calls respAreaToolbar with correct params', () => {
     render(<ExplicitConstructedResponse {...defaultProps} />);
-    expect(mockOptions.respAreaToolbar).toHaveBeenCalledWith(mockNode, mockEditor, expect.any(Function));
+    expect(mockOptions.respAreaToolbar).toHaveBeenCalledWith([mockNode, 5], mockEditor, expect.any(Function));
   });
 
   it('has cursor pointer style', () => {

--- a/packages/editable-html-tip-tap/src/components/__tests__/InlineDropdown.test.jsx
+++ b/packages/editable-html-tip-tap/src/components/__tests__/InlineDropdown.test.jsx
@@ -132,7 +132,7 @@ describe('InlineDropdown', () => {
 
   it('calls respAreaToolbar with correct params', () => {
     render(<InlineDropdown {...defaultProps} />);
-    expect(mockOptions.respAreaToolbar).toHaveBeenCalledWith(mockNode, mockEditor, expect.any(Function));
+    expect(mockOptions.respAreaToolbar).toHaveBeenCalledWith([mockNode, 5], mockEditor, expect.any(Function));
   });
 
   it('closes toolbar on outside click', async () => {

--- a/packages/editable-html-tip-tap/src/components/respArea/ExplicitConstructedResponse.jsx
+++ b/packages/editable-html-tip-tap/src/components/respArea/ExplicitConstructedResponse.jsx
@@ -9,7 +9,7 @@ const ExplicitConstructedResponse = (props) => {
   const { respAreaToolbar, error: errorFn } = options;
   const pos = getPos();
   const [showToolbar, setShowToolbar] = useState(false);
-  const EcrToolbar = respAreaToolbar(node, editor, () => {});
+  const EcrToolbar = respAreaToolbar([node, pos], editor, () => {});
   const toolbarRef = useRef(null);
 
   let error;

--- a/packages/editable-html-tip-tap/src/components/respArea/InlineDropdown.jsx
+++ b/packages/editable-html-tip-tap/src/components/respArea/InlineDropdown.jsx
@@ -11,11 +11,12 @@ const InlineDropdown = (props) => {
   // TODO: Investigate
   // Needed because items with values inside have different positioning for some reason
   const html = value || '<div>&nbsp</div>';
+  const pos = getPos();
   const toolbarRef = useRef(null);
   const toolbarEditor = useRef(null);
   const [showToolbar, setShowToolbar] = useState(false);
   const [position, setPosition] = useState({ top: 0, left: 0 });
-  const InlineDropdownToolbar = options.respAreaToolbar(node, editor, () => {});
+  const InlineDropdownToolbar = options.respAreaToolbar([node, pos], editor, () => {});
 
   useEffect(() => {
     const { selection } = editor.state;


### PR DESCRIPTION
fix: provided the pos of the node as well in the response area toolbar callback [PD-5787]