### PR TITLE
fix(math-rendering): always emit mjx-assistive-mml so screen readers read math correctly PIE-147

### DIFF
--- a/packages/math-rendering/src/render-math.js
+++ b/packages/math-rendering/src/render-math.js
@@ -269,14 +269,28 @@ const bootstrap = (opts) => {
 
         updatedDocument = updatedDocument.getMetrics().typeset();
 
-        // Only add assistive MML and speech if speech-rule-engine is ready and not in temporary mode
+        // assistiveMml() is what produces the <mjx-assistive-mml> element that
+        // screen readers (VoiceOver, JAWS, NVDA) use to read math semantically.
+        // It only serializes MathJax's internal MathML tree via LimitedMmlVisitor
+        // and does NOT depend on speech-rule-engine, so it must always run –
+        // otherwise fractions, roots, etc. get flattened to raw digits in AT.
+        try {
+          updatedDocument = updatedDocument.assistiveMml();
+        } catch (e) {
+          // eslint-disable-next-line no-console
+          console.warn('[math-rendering] Failed to attach assistive MathML:', e);
+        }
+
+        // attachSpeech() relies on speech strings computed during enrich(),
+        // which requires speech-rule-engine to be ready. Skip it gracefully
+        // if SRE isn't initialised yet – screen readers will still read the
+        // MathML structure produced above.
         if (!temporary && sreReady) {
           try {
-            updatedDocument = updatedDocument.assistiveMml().attachSpeech();
+            updatedDocument = updatedDocument.attachSpeech();
           } catch (e) {
-            // If this fails, speech-rule-engine isn't ready
             // eslint-disable-next-line no-console
-            console.warn('[math-rendering] Speech-rule-engine not fully initialized, skipping assistive features');
+            console.warn('[math-rendering] Speech-rule-engine not fully initialized, skipping speech attachment');
             sreReady = false;
           }
         }


### PR DESCRIPTION
https://illuminate.atlassian.net/browse/PIE-147?focusedCommentId=2290779

The previous guard gated both assistiveMml() and attachSpeech() behind
`!temporary && sreReady`, which dropped <mjx-assistive-mml> from the DOM
whenever the speech-rule-engine wasn't initialised (or on the temporary
render pass). As a result, VoiceOver fell back to reading the raw CHTML
digits and announced expressions like `9 × 1/8` as "9 1 8" instead of
"nine times one eighth".

assistiveMml() only serializes MathJax's internal MathML tree via
LimitedMmlVisitor and has no dependency on SRE, so it is now called
unconditionally (wrapped in try/catch for safety). Only attachSpeech(),
which consumes speech strings computed during enrich(), remains gated
on sreReady.

Regression introduced in e17c4d2e7 (shipped in 4.1.0-next.1).