### PR TITLE
fix: clicking on a different math node closes current modal [PIE-603]

### DIFF
--- a/packages/editable-html-tip-tap/src/extensions/__tests__/math.test.js
+++ b/packages/editable-html-tip-tap/src/extensions/__tests__/math.test.js
@@ -568,6 +568,66 @@ describe('MathNodeView', () => {
     });
   });
 
+  describe('unique math-node class per instance', () => {
+    let dateNowSpy;
+
+    beforeEach(() => {
+      let timestamp = 1000;
+      dateNowSpy = jest.spyOn(Date, 'now').mockImplementation(() => timestamp++);
+    });
+
+    afterEach(() => {
+      dateNowSpy.mockRestore();
+    });
+
+    it('assigns a timestamp-based class to NodeViewWrapper', () => {
+      const { getByTestId } = render(<MathNodeView {...defaultProps} />);
+      const wrapper = getByTestId('node-view-wrapper');
+
+      expect(wrapper.className).toMatch(/^math-node-\d+$/);
+    });
+
+    it('assigns a different class to each MathNodeView instance', () => {
+      const { getAllByTestId } = render(
+        <>
+          <MathNodeView {...defaultProps} />
+          <MathNodeView {...defaultProps} node={{ attrs: { latex: 'y^2' } }} />
+        </>,
+      );
+
+      const wrappers = getAllByTestId('node-view-wrapper');
+      expect(wrappers[0].className).toBe('math-node-1000');
+      expect(wrappers[1].className).toBe('math-node-1001');
+    });
+
+    it('closes toolbar when clicking a different math node', async () => {
+      const updateAttributes = jest.fn();
+      const editorA = createMockEditor();
+      const editorB = createMockEditor();
+
+      const { getAllByTestId, queryAllByTestId } = render(
+        <>
+          <MathNodeView {...defaultProps} editor={editorA} updateAttributes={updateAttributes} selected={true} />
+          <MathNodeView {...defaultProps} editor={editorB} node={{ attrs: { latex: 'y^2' } }} selected={false} />
+        </>,
+      );
+
+      await waitFor(() => {
+        expect(queryAllByTestId('math-toolbar')).toHaveLength(1);
+      });
+
+      const secondPreview = getAllByTestId('math-preview')[1];
+      fireEvent.click(secondPreview);
+
+      await waitFor(() => {
+        expect(queryAllByTestId('math-toolbar')).toHaveLength(1);
+        expect(updateAttributes).toHaveBeenCalledWith({ latex: 'x^2' });
+        expect(editorA._toolbarOpened).toBe(false);
+        expect(getAllByTestId('math-input')[0]).toHaveValue('y^2');
+      });
+    });
+  });
+
   it('does not close toolbar when clicking equation editor dropdown', async () => {
     const { queryByTestId } = render(<MathNodeView {...defaultProps} selected={true} />);
 

--- a/packages/editable-html-tip-tap/src/extensions/math.js
+++ b/packages/editable-html-tip-tap/src/extensions/math.js
@@ -183,6 +183,7 @@ export const MathNodeView = (props) => {
   const { node, updateAttributes, editor, selected, options } = props;
   const [showToolbar, setShowToolbar] = useState(selected);
   const toolbarRef = useRef(null);
+  const timestamp = useRef(Date.now());
   const [position, setPosition] = useState({ top: 0, left: 0 });
   const { math: mathOptions = {} } = options || {};
   const {
@@ -253,7 +254,7 @@ export const MathNodeView = (props) => {
       // will keep/re-open the toolbar. Without this guard, closing and then
       // immediately clicking the math node would fire this listener in the same
       // event cycle and close the toolbar before it could open.
-      const clickedMathNode = !!target?.closest?.('.math-node');
+      const clickedMathNode = !!target?.closest?.(`.math-node-${timestamp.current}`);
 
       if (
         toolbarRef.current &&
@@ -281,7 +282,7 @@ export const MathNodeView = (props) => {
 
   return (
     <NodeViewWrapper
-      className="math-node"
+      className={`math-node-${timestamp.current}`}
       style={{
         display: 'inline-flex',
         cursor: 'pointer',


### PR DESCRIPTION
fix: clicking on a different math node closes current modal [[PIE-603](https://illuminate.atlassian.net/browse/PIE-603)]