### PR TITLE
fix(text-select, editable-html-tip-tap): update generic classnames, add better scoping

### DIFF
--- a/packages/editable-html-tip-tap/src/components/MenuBar.jsx
+++ b/packages/editable-html-tip-tap/src/components/MenuBar.jsx
@@ -436,7 +436,7 @@ const StyledMenuBar = (props) => {
   const classes = {
     defaultToolbar: 'defaultToolbar',
     buttonsContainer: 'buttonsContainer',
-    button: 'button',
+    button: 'toolbarButton',
     active: 'active',
     disabled: 'disabled',
     isActive: 'isActive',
@@ -471,7 +471,7 @@ const StyledMenuBarRoot = styled('div')(({ theme }) => ({
     display: 'flex',
     width: '100%',
   },
-  '& .button': {
+  '& .toolbarButton': {
     color: 'grey',
     display: 'inline-flex',
     padding: '2px',

--- a/packages/text-select/src/token-select/__tests__/token.test.jsx
+++ b/packages/text-select/src/token-select/__tests__/token.test.jsx
@@ -6,7 +6,7 @@ describe('token', () => {
   const defaultProps = {
     classes: {
       token: 'token',
-      selectable: 'selectable',
+      selectable: 'selectableToken',
     },
     text: 'foo bar',
   };
@@ -54,31 +54,31 @@ describe('token', () => {
   });
 
   describe('selectable state', () => {
-    it('applies selectable class when selectable is true', () => {
+    it('applies selectableToken class when selectable is true', () => {
       const { container } = render(<Token {...defaultProps} selectable={true} />);
-      expect(container.querySelector('.selectable')).toBeInTheDocument();
+      expect(container.querySelector('.selectableToken')).toBeInTheDocument();
     });
 
-    it('does not apply selectable class when selectable is false', () => {
+    it('does not apply selectableToken class when selectable is false', () => {
       const { container } = render(<Token {...defaultProps} selectable={false} />);
-      expect(container.querySelector('.selectable')).not.toBeInTheDocument();
+      expect(container.querySelector('.selectableToken')).not.toBeInTheDocument();
     });
 
-    it('does not apply selectable class when disabled', () => {
+    it('does not apply selectableToken class when disabled', () => {
       const { container } = render(<Token {...defaultProps} selectable={true} disabled={true} />);
-      expect(container.querySelector('.selectable')).not.toBeInTheDocument();
+      expect(container.querySelector('.selectableToken')).not.toBeInTheDocument();
     });
   });
 
   describe('selected state', () => {
-    it('applies selected class when selected is true', () => {
+    it('applies selectedToken class when selected is true', () => {
       const { container } = render(<Token {...defaultProps} selected={true} />);
-      expect(container.querySelector('.selected')).toBeInTheDocument();
+      expect(container.querySelector('.selectedToken')).toBeInTheDocument();
     });
 
-    it('does not apply selected class when selected is false', () => {
+    it('does not apply selectedToken class when selected is false', () => {
       const { container } = render(<Token {...defaultProps} selected={false} />);
-      expect(container.querySelector('.selected')).not.toBeInTheDocument();
+      expect(container.querySelector('.selectedToken')).not.toBeInTheDocument();
     });
 
     it('applies disabledBlack class when selected and disabled without correct prop', () => {
@@ -208,7 +208,7 @@ describe('token', () => {
   describe('className combinations', () => {
     it('combines multiple state classes', () => {
       const { container } = render(<Token {...defaultProps} selectable={true} selected={true} highlight={true} />);
-      expect(container.querySelector('.selected')).toBeInTheDocument();
+      expect(container.querySelector('.selectedToken')).toBeInTheDocument();
     });
 
     it('applies correct precedence for disabled and selected', () => {

--- a/packages/text-select/src/token-select/token.jsx
+++ b/packages/text-select/src/token-select/token.jsx
@@ -29,7 +29,7 @@ const StyledToken = styled('span')(({ theme }) => ({
     backgroundColor: color.blueGrey100(),
   },
   [`@media (min-width: ${theme.breakpoints.values.md}px)`]: {
-    '&.selectable:hover': {
+    '&.selectableToken:hover': {
       backgroundColor: color.blueGrey300(),
       color: theme.palette.common.black,
       '& > *': {
@@ -37,7 +37,7 @@ const StyledToken = styled('span')(({ theme }) => ({
       },
     },
   },
-  '&.selected': {
+  '&.selectedToken': {
     backgroundColor: color.blueGrey100(),
     color: theme.palette.common.black,
     lineHeight: `${parseFloat(theme.spacing(1)) * LINE_HEIGHT_MULTIPLIER}px`,
@@ -161,7 +161,7 @@ export class Token extends React.Component {
 
     if (correct === undefined && selected && disabled) {
       return {
-        className: classNames(baseClassName, 'selected', 'disabledBlack', classNameProp),
+        className: classNames(baseClassName, 'selectedToken', 'disabledBlack', classNameProp),
         Component: StyledToken,
       };
     }
@@ -189,8 +189,8 @@ export class Token extends React.Component {
       className: classNames(
         baseClassName,
         disabled && 'disabled',
-        selectable && !disabled && !isTouchEnabled && 'selectable',
-        selected && !disabled && 'selected',
+        selectable && !disabled && !isTouchEnabled && 'selectableToken',
+        selected && !disabled && 'selectedToken',
         selected && disabled && 'disabledAndSelected',
         highlight && selectable && !disabled && !selected && 'highlight',
         animationsDisabled && 'print',


### PR DESCRIPTION
The classnames had too generic names and interfere with other classes in DNA
[PIE-663](https://illuminate.atlassian.net/browse/PIE-663) - select-text

`selectable` → `selectableToken`
`selected` → `selectedToken`

[PIE-662](https://illuminate.atlassian.net/browse/PIE-662) - extended-text-entry
`button`-> `toolbarButton`
