### PR TITLE
fix(editable-html-tip-tap): explicitly set SVG icon in toolbar button…

### DIFF
--- a/packages/editable-html-tip-tap/src/components/common/toolbar-buttons.jsx
+++ b/packages/editable-html-tip-tap/src/components/common/toolbar-buttons.jsx
@@ -12,6 +12,11 @@ const StyledButton = styled('button', {
   background: 'none',
   border: 'none',
   cursor: disabled ? 'not-allowed' : 'pointer',
+  // previously we had implicit 24×24 icon rendering for mui svg icons, but now we need to explicitly set the size to 24×24 to match the previous behavior
+  '& svg': {
+    width: '24px',
+    height: '24px',
+  },
   '&:hover': {
     color: disabled ? 'grey' : 'black',
   },


### PR DESCRIPTION
… size to 24x24 for consistency

Some environments have this on the page:
`svg[Attributes Style] {
    height: 24px;
    width: 24px;
    fill: none;
}`
but we still need explicit dimensions because not all of them have it (OT does not) 
https://illuminate.atlassian.net/browse/PIE-662 