### PR TITLE
fix: open math in custom toolbars, higher zIndex for character picker, math deletion, math selection, math and character position [PIE-656][PIE-657][PIE-658][PIE-659]

### DIFF
--- a/packages/editable-html-tip-tap/src/components/CharacterPicker.jsx
+++ b/packages/editable-html-tip-tap/src/components/CharacterPicker.jsx
@@ -135,7 +135,7 @@ export function CharacterPicker({ editor, opts, onClose }) {
             top: `${position.top}px`,
             left: `${position.left}px`,
             maxWidth: '500px',
-            zIndex: 99,
+            zIndex: 1000,
           }}
         >
           <div>

--- a/packages/editable-html-tip-tap/src/components/__tests__/CharacterPicker.test.jsx
+++ b/packages/editable-html-tip-tap/src/components/__tests__/CharacterPicker.test.jsx
@@ -237,6 +237,15 @@ describe('CharacterPicker', () => {
     expect(dialog).toHaveStyle({ position: 'absolute' });
   });
 
+  it('renders above other editor overlays with a high z-index', () => {
+    const opts = {
+      characters: [['á']],
+    };
+    const { container } = render(<CharacterPicker editor={mockEditor} opts={opts} onClose={jest.fn()} />);
+    const dialog = container.querySelector('.insert-character-dialog');
+    expect(dialog).toHaveStyle({ zIndex: '1000' });
+  });
+
   it('adds data-toolbar-for attribute with editor instanceId', () => {
     const editorWithInstanceId = {
       ...mockEditor,

--- a/packages/editable-html-tip-tap/src/extensions/__tests__/math.test.js
+++ b/packages/editable-html-tip-tap/src/extensions/__tests__/math.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { render, waitFor, fireEvent } from '@testing-library/react';
 import { EnsureTextAfterMathPlugin, MathNode, MathNodeView, ZeroWidthSpaceHandlingPlugin } from '../math';
+import * as toolbarUtils from '../../utils/toolbar';
 
 jest.mock('@tiptap/react', () => ({
   NodeViewWrapper: ({ children, ...props }) => (
@@ -147,6 +148,35 @@ describe('MathNode', () => {
       expect(commands).toHaveProperty('insertMath');
       expect(typeof commands.insertMath).toBe('function');
     });
+
+    it('insertMath opens the toolbar after inserting a math node', () => {
+      const setToolbarOpenedSpy = jest.spyOn(toolbarUtils, 'setToolbarOpened');
+      const mathNode = { type: { name: 'math' }, nodeSize: 1 };
+      const tr = {
+        insert: jest.fn().mockReturnThis(),
+        setSelection: jest.fn().mockReturnThis(),
+        doc: {},
+      };
+      const editor = {
+        view: {
+          state: {
+            schema: { nodes: { math: { create: jest.fn(() => mathNode) } } },
+            selection: { $from: { pos: 1 } },
+          },
+        },
+      };
+      const dispatch = jest.fn();
+      const insertMath = MathNode.addCommands().insertMath('x^2');
+
+      insertMath({ tr, editor, dispatch });
+
+      expect(tr.insert).toHaveBeenCalledWith(1, mathNode);
+      expect(tr.setSelection).toHaveBeenCalled();
+      expect(dispatch).toHaveBeenCalledWith(tr);
+      expect(setToolbarOpenedSpy).toHaveBeenCalledWith(editor, true);
+
+      setToolbarOpenedSpy.mockRestore();
+    });
   });
 
   describe('addNodeView', () => {
@@ -219,12 +249,32 @@ describe('EnsureTextAfterMathPlugin', () => {
 });
 
 describe('ZeroWidthSpaceHandlingPlugin', () => {
-  const createDefaultDoc = () => ({
-    textBetween: jest.fn(() => '\u200b'),
-    resolve: jest.fn(() => ({
+  const createDocWithMathAndZwsp = (resolveOverrides = {}) => ({
+    resolve: jest.fn((pos) => ({
       nodeAfter: null,
       nodeBefore: null,
+      pos,
+      ...resolveOverrides[pos],
     })),
+    nodeAt: jest.fn((pos) => {
+      if (pos === 1) {
+        return { type: { name: 'text' }, textContent: '\u200b' };
+      }
+      if (pos === 0) {
+        return { type: { name: 'math' }, nodeSize: 1 };
+      }
+      return null;
+    }),
+  });
+
+  const createDocWithRegularTextBeforeCursor = () => ({
+    resolve: jest.fn((pos) => ({ nodeAfter: null, nodeBefore: null, pos })),
+    nodeAt: jest.fn((pos) => {
+      if (pos === 1) {
+        return { type: { name: 'text' }, textContent: 'a' };
+      }
+      return null;
+    }),
   });
 
   const createView = ({ state: stateOverrides = {} } = {}) => {
@@ -237,66 +287,88 @@ describe('ZeroWidthSpaceHandlingPlugin', () => {
     return {
       state: {
         selection: { from: 2, empty: true },
-        doc: createDefaultDoc(),
+        doc: createDocWithMathAndZwsp(),
         tr,
         ...stateOverrides,
-        doc: { ...createDefaultDoc(), ...stateOverrides.doc },
       },
       dispatch,
     };
   };
 
-  it('deletes math and zero-width space on Backspace', () => {
-    const view = createView();
-    const event = { key: 'Backspace' };
-    const handled = ZeroWidthSpaceHandlingPlugin.props.handleKeyDown(view, event);
+  describe('Backspace', () => {
+    it('deletes the inline node and zero-width space before the cursor', () => {
+      const view = createView();
+      const handled = ZeroWidthSpaceHandlingPlugin.props.handleKeyDown(view, { key: 'Backspace' });
 
-    expect(handled).toBe(true);
-    expect(view.state.tr.delete).toHaveBeenCalledWith(0, 2);
-    expect(view.dispatch).toHaveBeenCalledWith(view.state.tr);
-  });
-
-  it('selects the math node on ArrowLeft before a zero-width space', () => {
-    const mathNode = { nodeSize: 3 };
-    const view = createView({
-      state: {
-        doc: {
-          resolve: jest
-            .fn()
-            .mockReturnValueOnce({ nodeAfter: mathNode, nodeBefore: null })
-            .mockReturnValueOnce({ pos: 4 }),
-        },
-      },
+      expect(handled).toBe(true);
+      expect(view.state.tr.delete).toHaveBeenCalledWith(0, 2);
+      expect(view.dispatch).toHaveBeenCalledWith(view.state.tr);
     });
-    const { NodeSelection } = require('prosemirror-state');
 
-    const handled = ZeroWidthSpaceHandlingPlugin.props.handleKeyDown(view, { key: 'ArrowLeft' });
+    it('returns false when regular text precedes the cursor', () => {
+      const view = createView({
+        state: {
+          doc: createDocWithRegularTextBeforeCursor(),
+        },
+      });
 
-    expect(handled).toBe(true);
-    expect(NodeSelection.create).toHaveBeenCalledWith(view.state.doc, 4);
-    expect(view.dispatch).toHaveBeenCalled();
+      const handled = ZeroWidthSpaceHandlingPlugin.props.handleKeyDown(view, { key: 'Backspace' });
+
+      expect(handled).toBe(false);
+      expect(view.state.tr.delete).not.toHaveBeenCalled();
+      expect(view.dispatch).not.toHaveBeenCalled();
+    });
   });
 
-  it('moves the text cursor before the zero-width space when no inline node precedes it', () => {
-    const view = createView();
-    const { TextSelection } = require('prosemirror-state');
+  describe('ArrowLeft', () => {
+    it('selects the inline node before a zero-width space', () => {
+      const mathNode = { nodeSize: 3 };
+      const view = createView({
+        state: {
+          doc: createDocWithMathAndZwsp({
+            0: { nodeAfter: mathNode, nodeBefore: null, pos: 0 },
+          }),
+        },
+      });
+      const { NodeSelection } = require('prosemirror-state');
 
-    const handled = ZeroWidthSpaceHandlingPlugin.props.handleKeyDown(view, { key: 'ArrowLeft' });
+      const handled = ZeroWidthSpaceHandlingPlugin.props.handleKeyDown(view, { key: 'ArrowLeft' });
 
-    expect(handled).toBe(true);
-    expect(TextSelection.create).toHaveBeenCalledWith(view.state.doc, 0);
-    expect(view.dispatch).toHaveBeenCalled();
+      expect(handled).toBe(true);
+      expect(view.state.doc.resolve).toHaveBeenCalledWith(0);
+      expect(NodeSelection.create).toHaveBeenCalledWith(view.state.doc, 0);
+      expect(view.dispatch).toHaveBeenCalled();
+    });
+
+    it('moves the text cursor before the zero-width space when no inline node precedes it', () => {
+      const view = createView();
+      const { TextSelection } = require('prosemirror-state');
+
+      const handled = ZeroWidthSpaceHandlingPlugin.props.handleKeyDown(view, { key: 'ArrowLeft' });
+
+      expect(handled).toBe(true);
+      expect(view.state.doc.resolve).toHaveBeenCalledWith(0);
+      expect(TextSelection.create).toHaveBeenCalledWith(view.state.doc, 0);
+      expect(view.dispatch).toHaveBeenCalled();
+    });
+
+    it('returns false when regular text precedes the cursor', () => {
+      const view = createView({
+        state: {
+          doc: createDocWithRegularTextBeforeCursor(),
+        },
+      });
+
+      const handled = ZeroWidthSpaceHandlingPlugin.props.handleKeyDown(view, { key: 'ArrowLeft' });
+
+      expect(handled).toBe(false);
+      expect(view.state.tr.setSelection).not.toHaveBeenCalled();
+      expect(view.dispatch).not.toHaveBeenCalled();
+    });
   });
 
   it('returns false for unrelated keys', () => {
-    const view = createView({
-      state: {
-        doc: {
-          textBetween: jest.fn(() => 'a'),
-          resolve: jest.fn(),
-        },
-      },
-    });
+    const view = createView();
 
     const handled = ZeroWidthSpaceHandlingPlugin.props.handleKeyDown(view, { key: 'Enter' });
     expect(handled).toBe(false);
@@ -304,6 +376,15 @@ describe('ZeroWidthSpaceHandlingPlugin', () => {
 });
 
 describe('MathNodeView', () => {
+  const createEditorElement = (rect = { top: 0, left: 0, width: 600, height: 400 }) => {
+    const element = document.createElement('div');
+    Object.defineProperty(element, 'getBoundingClientRect', {
+      value: jest.fn(() => rect),
+      configurable: true,
+    });
+    return element;
+  };
+
   const createMockEditor = () => ({
     state: {
       selection: {
@@ -320,6 +401,9 @@ describe('MathNodeView', () => {
       coordsAtPos: jest.fn(() => ({ top: 100, left: 50 })),
       dispatch: jest.fn(),
     },
+    options: {
+      element: createEditorElement(),
+    },
     commands: {
       focus: jest.fn(),
     },
@@ -334,13 +418,6 @@ describe('MathNodeView', () => {
   };
 
   let defaultProps;
-
-  beforeAll(() => {
-    Object.defineProperty(document.body, 'getBoundingClientRect', {
-      value: jest.fn(() => ({ top: 0, left: 0 })),
-      configurable: true,
-    });
-  });
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -390,30 +467,29 @@ describe('MathNodeView', () => {
   });
 
   describe('toolbar positioning', () => {
-    it('uses a fixed top offset and horizontal position from coordsAtPos', async () => {
+    it('positions relative to the editor element using coordsAtPos', async () => {
       const { container } = render(<MathNodeView {...defaultProps} selected={true} />);
       await waitFor(() => {
         const toolbar = container.querySelector('[data-toolbar-for]');
         expect(toolbar).toBeInTheDocument();
-        expect(toolbar.style.top).toBe('40px');
+        expect(toolbar.style.top).toBe('140px');
         expect(toolbar.style.left).toBe('50px');
       });
     });
 
-    it('keeps the fixed top offset when the editor container is scrolled', async () => {
-      const containerEl = document.createElement('div');
-      containerEl.getBoundingClientRect = jest.fn(() => ({ top: -200, left: 0, width: 600, height: 400 }));
+    it('accounts for editor scroll offset when calculating toolbar position', async () => {
+      const editorElement = createEditorElement({ top: -200, left: 0, width: 600, height: 400 });
 
       const editor = {
         ...defaultProps.editor,
-        _tiptapContainerEl: containerEl,
+        options: { element: editorElement },
       };
 
       const { container } = render(<MathNodeView {...defaultProps} editor={editor} selected={true} />);
       await waitFor(() => {
         const toolbar = container.querySelector('[data-toolbar-for]');
         expect(toolbar).toBeInTheDocument();
-        expect(toolbar.style.top).toBe('40px');
+        expect(toolbar.style.top).toBe('340px');
         expect(toolbar.style.left).toBe('50px');
       });
     });
@@ -427,7 +503,7 @@ describe('MathNodeView', () => {
       });
     });
 
-    it('updates horizontal position from coordsAtPos when selection changes', async () => {
+    it('updates position from coordsAtPos when selection changes', async () => {
       const editor = {
         ...defaultProps.editor,
         view: {
@@ -441,7 +517,7 @@ describe('MathNodeView', () => {
       await waitFor(() => {
         const toolbar = container.querySelector('[data-toolbar-for]');
         expect(toolbar).toBeInTheDocument();
-        expect(toolbar.style.top).toBe('40px');
+        expect(toolbar.style.top).toBe('240px');
         expect(toolbar.style.left).toBe('150px');
       });
     });
@@ -515,18 +591,35 @@ describe('MathNodeView', () => {
     });
   });
 
-  it('unsets editor._toolbarOpened when toolbar is closed', async () => {
+  it('unsets editor._toolbarOpened when toolbar is closed and node is not selected', async () => {
+    const { getByTestId } = render(<MathNodeView {...defaultProps} selected={false} />);
+
+    fireEvent.click(getByTestId('math-preview'));
+
+    await waitFor(() => {
+      expect(getByTestId('math-toolbar')).toBeInTheDocument();
+      expect(defaultProps.editor._toolbarOpened).toBe(true);
+    });
+
+    fireEvent.click(getByTestId('done-button'));
+
+    await waitFor(() => {
+      expect(defaultProps.editor._toolbarOpened).toBe(false);
+    });
+  });
+
+  it('keeps editor._toolbarOpened true while the math node remains selected', async () => {
     const { getByTestId } = render(<MathNodeView {...defaultProps} selected={true} />);
 
     await waitFor(() => {
       expect(getByTestId('done-button')).toBeInTheDocument();
+      expect(defaultProps.editor._toolbarOpened).toBe(true);
     });
 
-    const doneButton = getByTestId('done-button');
-    fireEvent.click(doneButton);
+    fireEvent.click(getByTestId('done-button'));
 
     await waitFor(() => {
-      expect(defaultProps.editor._toolbarOpened).toBe(false);
+      expect(defaultProps.editor._toolbarOpened).toBe(true);
     });
   });
 
@@ -551,7 +644,7 @@ describe('MathNodeView', () => {
       expect(editor.state.tr.setSelection).toHaveBeenCalled();
       expect(editor.view.dispatch).toHaveBeenCalledWith(editor.state.tr);
       expect(editor.commands.focus).toHaveBeenCalled();
-      expect(editor._toolbarOpened).toBe(false);
+      expect(editor._toolbarOpened).toBe(true);
     });
   });
 
@@ -608,10 +701,12 @@ describe('MathNodeView', () => {
 
       const { getAllByTestId, queryAllByTestId } = render(
         <>
-          <MathNodeView {...defaultProps} editor={editorA} updateAttributes={updateAttributes} selected={true} />
+          <MathNodeView {...defaultProps} editor={editorA} updateAttributes={updateAttributes} selected={false} />
           <MathNodeView {...defaultProps} editor={editorB} node={{ attrs: { latex: 'y^2' } }} selected={false} />
         </>,
       );
+
+      fireEvent.click(getAllByTestId('math-preview')[0]);
 
       await waitFor(() => {
         expect(queryAllByTestId('math-toolbar')).toHaveLength(1);

--- a/packages/editable-html-tip-tap/src/extensions/math.js
+++ b/packages/editable-html-tip-tap/src/extensions/math.js
@@ -45,6 +45,26 @@ export const EnsureTextAfterMathPlugin = (mathNodeName) =>
     },
   });
 
+const nodeBeforeZeroWidthSpace = (doc, from) => {
+  let i;
+
+  // finding if previous to the cursor there's a zero-width space
+  // and a non-text element, and deleting everything until the space
+  for (i = from; i > 0; i--) {
+    const currentDoc = doc.nodeAt(i);
+
+    if (currentDoc?.type?.name === 'text' && currentDoc.textContent !== '\u200b') {
+      return -1;
+    }
+
+    if (currentDoc && currentDoc?.type?.name !== 'text') {
+      break;
+    }
+  }
+
+  return i;
+};
+
 export const ZeroWidthSpaceHandlingPlugin = new Plugin({
   key: new PluginKey('zeroWidthSpaceHandling'),
   props: {
@@ -54,35 +74,38 @@ export const ZeroWidthSpaceHandlingPlugin = new Plugin({
       const { from, empty } = selection;
 
       if (empty && event.key === 'Backspace' && from > 0) {
-        const prevChar = doc.textBetween(from - 1, from, '\uFFFC', '\uFFFC');
-        if (prevChar === '\u200b') {
-          const tr = state.tr.delete(from - 2, from);
-          dispatch(tr);
-          return true; // handled
+        const start = nodeBeforeZeroWidthSpace(doc, from);
+
+        if (start === -1) {
+          return false;
         }
+
+        const tr = state.tr.delete(start, from);
+        dispatch(tr);
+        return true; // handled
       }
 
       if (empty && event.key === 'ArrowLeft' && from > 0) {
-        const prevChar = doc.textBetween(from - 1, from, '\uFFFC', '\uFFFC');
-        // If the previous character is the zero-width space...
-        if (prevChar === '\u200b') {
-          const posBefore = from - 1;
-          const resolved = state.doc.resolve(posBefore - 1); // look just before the zwsp
-          const maybeNode = resolved.nodeAfter || resolved.nodeBefore;
+        const start = nodeBeforeZeroWidthSpace(doc, from);
 
-          // Check if there's an inline selectable node (e.g., your math node)
-          if (maybeNode) {
-            const nodePos = posBefore - maybeNode.nodeSize;
-            const nodeResolved = state.doc.resolve(nodePos);
-            const tr = state.tr.setSelection(NodeSelection.create(state.doc, nodeResolved.pos));
-            dispatch(tr);
-            return true;
-          } else {
-            // Just move the text cursor before the zwsp
-            const tr = state.tr.setSelection(TextSelection.create(state.doc, from - 2));
-            dispatch(tr);
-            return true;
-          }
+        if (start === -1) {
+          return false;
+        }
+
+        const resolved = state.doc.resolve(start);
+        const maybeNode = resolved.nodeAfter || resolved.nodeBefore;
+
+        // Check if there's an inline selectable node (e.g., your math node)
+        if (maybeNode) {
+          const nodeResolved = state.doc.resolve(start);
+          const tr = state.tr.setSelection(NodeSelection.create(state.doc, nodeResolved.pos));
+          dispatch(tr);
+          return true;
+        } else {
+          // Just move the text cursor before the zwsp
+          const tr = state.tr.setSelection(TextSelection.create(state.doc, from - 2));
+          dispatch(tr);
+          return true;
         }
       }
 
@@ -152,14 +175,9 @@ export const MathNode = Node.create({
 
           dispatch(tr);
 
+          setToolbarOpened(editor, true);
           return true;
         },
-      // insertMath: (latex = '') => ({ commands }) => {
-      //   return commands.insertContent({
-      //     type: this.name,
-      //     attrs: { latex },
-      //   });
-      // },
     };
   },
 
@@ -221,16 +239,19 @@ export const MathNodeView = (props) => {
   }, [selected]);
 
   useEffect(() => {
-    setToolbarOpened(editor, showToolbar);
-  }, [editor, showToolbar]);
+    setToolbarOpened(editor, selected || showToolbar);
+  }, [editor, showToolbar, selected]);
 
   useEffect(() => {
     // Calculate position relative to selection
     const { from } = editor.state.selection;
     const start = editor.view.coordsAtPos(from);
+    const editorDOM = editor.options.element;
+    const editorRect = editorDOM.getBoundingClientRect();
+
     setPosition({
-      top: 40, // shift above
-      left: start.left,
+      top: start.top - editorRect.top + 40, // shift above
+      left: start.left - editorRect.left,
     });
 
     const handleClickOutside = (event) => {


### PR DESCRIPTION
fix: open math in custom toolbars, higher zIndex for character picker, math deletion, math selection, math and character position [[PIE-656](https://illuminate.atlassian.net/browse/PIE-656)][[PIE-657](https://illuminate.atlassian.net/browse/PIE-657)][[PIE-658](https://illuminate.atlassian.net/browse/PIE-658)][[PIE-659](https://illuminate.atlassian.net/browse/PIE-659)]