### PR TITLE
fix(mask-markup/choice): add fallback dimensions for dragging state i…

### DIFF
--- a/packages/mask-markup/src/choices/choice.jsx
+++ b/packages/mask-markup/src/choices/choice.jsx
@@ -71,8 +71,8 @@ export default function Choice({ choice, disabled, instanceId }) {
       style={
         isDragging
           ? {
-              width: rootRef.current?.offsetWidth,
-              height: rootRef.current?.offsetHeight,
+               width: rootRef.current?.offsetWidth || 90, // min-width of chip is 90px, so if we don't have the width, we can use 90px as a fallback
+               height: rootRef.current?.offsetHeight || 32, // min-height of chip is 32px, so if we don't have the height, we can use 32px as a fallback
             }
           : {}
       }


### PR DESCRIPTION
…n Choice component PIE-693

https://illuminate.atlassian.net/browse/PIE-693 

The issue was that when you start dragging a chip, the code needs to know how big it should be while it's being dragged — basically taking a "snapshot" of its size. But on the very first drag in some environments, that measurement wasn't ready yet, so the code got a size of zero. Zero width and zero height means invisible.

The fix: Added a safety net — if the measurement comes back as zero (or isn't ready), use a sensible minimum size instead. That way the chip is always visible while being dragged, even on the first try. 