### PR TITLE
fix(theming): move the grey palette reads onto --pie-* tokens PIE-856

### DIFF
--- a/packages/config-ui/src/choice-configuration/index.jsx
+++ b/packages/config-ui/src/choice-configuration/index.jsx
@@ -5,7 +5,7 @@ import TextField from '@mui/material/TextField';
 import ActionDelete from '@mui/icons-material/Delete';
 import ArrowRight from '@mui/icons-material/SubdirectoryArrowRight';
 import IconButton from '@mui/material/IconButton';
-import { InputContainer } from '@pie-lib/render-ui';
+import { InputContainer, color } from '@pie-lib/render-ui';
 import EditableHtml from '@pie-lib/editable-html-tip-tap';
 import { InputCheckbox, InputRadio } from '../inputs';
 import FeedbackMenu from './feedback-menu';
@@ -61,8 +61,10 @@ const StyledFeedbackContainer = styled('div')(() => ({
   position: 'relative',
 }));
 
-const StyledArrowIcon = styled(ArrowRight)(({ theme }) => ({
-  fill: theme.palette.grey[400],
+// The arrow is a connector: it is the only thing tying the feedback field to the
+// choice above it, so it takes a stroke token that clears 3:1 in every scheme.
+const StyledArrowIcon = styled(ArrowRight)(() => ({
+  fill: color.border(),
   left: -56,
   position: 'absolute',
   top: 40,

--- a/packages/config-ui/src/feedback-config/feedback-selector.jsx
+++ b/packages/config-ui/src/feedback-config/feedback-selector.jsx
@@ -1,5 +1,5 @@
 import EditableHtml from '@pie-lib/editable-html-tip-tap';
-import { InputContainer } from '@pie-lib/render-ui';
+import { InputContainer, color } from '@pie-lib/render-ui';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { styled } from '@mui/material/styles';
@@ -24,9 +24,11 @@ const StyledInputContainer = styled(InputContainer)(() => ({
   paddingBottom: 0,
 }));
 
+// A fill is meant to sit close to the page, so `--pie-background-dark` rather
+// than a stroke token; MUI's grey[300] held #e0e0e0 under every scheme.
 const StyledCustomHolder = styled('div')(({ theme }) => ({
   marginTop: '0px',
-  background: theme.palette.grey[300],
+  background: color.backgroundDark(),
   padding: 0,
   marginBottom: theme.spacing(2),
   borderRadius: '4px',
@@ -34,7 +36,7 @@ const StyledCustomHolder = styled('div')(({ theme }) => ({
 
 const StyledDefaultHolder = styled('div')(({ theme }) => ({
   marginTop: '0px',
-  background: theme.palette.grey[300],
+  background: color.backgroundDark(),
   padding: theme.spacing(2),
   marginBottom: theme.spacing(2),
   borderRadius: '4px',

--- a/packages/config-ui/src/help.jsx
+++ b/packages/config-ui/src/help.jsx
@@ -10,10 +10,14 @@ import HelpIcon from '@mui/icons-material/Help';
 import IconButton from '@mui/material/IconButton';
 import React from 'react';
 import { styled } from '@mui/material/styles';
+import { color } from '@pie-lib/render-ui';
 
-const StyledIconButton = styled(IconButton)(({ theme }) => ({
+const StyledIconButton = styled(IconButton)(() => ({
   '&:hover': {
-    color: theme.palette.grey[300],
+    // A decorative de-emphasis on hover -- the icon's resting state carries the
+    // affordance, so this does not need the 3:1 non-text minimum. MUI's grey[300]
+    // did not follow `--pie-*`, so it stayed #e0e0e0 on a dark scheme's surface.
+    color: color.borderLight(),
   },
 }));
 

--- a/packages/config-ui/src/layout/settings-box.jsx
+++ b/packages/config-ui/src/layout/settings-box.jsx
@@ -1,10 +1,18 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { styled } from '@mui/material/styles';
+import { color } from '@pie-lib/render-ui';
 
-const StyledSettingsBox = styled('div')(({ theme }) => ({
-  backgroundColor: theme.palette.background.paper,
-  border: `2px solid ${theme.palette.grey[200]}`,
+const StyledSettingsBox = styled('div')(() => ({
+  /*
+   * Surface and stroke have to move together. `background.paper` is MUI's #fff
+   * regardless of scheme, so tokenising the stroke alone would put a scheme's
+   * border colour on a fixed white panel -- under white-on-black that is a white
+   * stroke on white. `--pie-white` inverts with the scheme, which is what the
+   * panel wanted from `background.paper` in the first place.
+   */
+  backgroundColor: color.white(),
+  border: `2px solid ${color.border()}`,
   display: 'flex',
   flexDirection: 'column',
   justifyContent: 'flex-start',

--- a/packages/editable-html-tip-tap/src/components/MenuBar.jsx
+++ b/packages/editable-html-tip-tap/src/components/MenuBar.jsx
@@ -2,6 +2,7 @@ import React, { useMemo, useState } from 'react';
 import classNames from 'classnames';
 import { styled, useTheme } from '@mui/material/styles';
 import { NodeSelection } from 'prosemirror-state';
+import { color } from '@pie-lib/render-ui';
 
 import Bold from '@mui/icons-material/FormatBold';
 import Italic from '@mui/icons-material/FormatItalic';
@@ -528,7 +529,7 @@ const StyledMenuBar = (props) => {
   );
 };
 
-const StyledMenuBarRoot = styled('div')(({ theme }) => ({
+const StyledMenuBarRoot = styled('div')(() => ({
   '& .defaultToolbar': {
     display: 'flex',
     width: '100%',
@@ -552,20 +553,26 @@ const StyledMenuBarRoot = styled('div')(({ theme }) => ({
       height: '24px',
     },
     '&:hover': {
-      color: 'black',
+      color: color.text(),
     },
     '&:focus': {
-      outline: `2px solid ${theme.palette.grey[700]}`,
+      /*
+       * A focus ring is the one thing a keyboard user cannot do without, so it takes
+       * the registered focus token rather than a grey. `--pie-button-focus-outline`
+       * measures at least 3.68:1 against every scheme's own background; MUI's
+       * grey[700] fell to 1.28:1 on yellow-on-navy.
+       */
+      outline: `2px solid ${color.buttonFocusOutline()}`,
     },
   },
   '& .active': {
-    color: 'black',
+    color: color.text(),
   },
   '& .disabled': {
     opacity: 0.7,
     cursor: 'not-allowed',
     '& :hover': {
-      color: 'grey',
+      color: color.disabled(),
     },
   },
   '& .isActive': {

--- a/packages/editable-html-tip-tap/src/components/__tests__/toolbar-buttons.test.jsx
+++ b/packages/editable-html-tip-tap/src/components/__tests__/toolbar-buttons.test.jsx
@@ -1,6 +1,19 @@
 import React from 'react';
 import { fireEvent, render } from '@testing-library/react';
+import { color } from '@pie-lib/render-ui';
 import { Button, MarkButton, RawButton, RawMarkButton } from '../common/toolbar-buttons';
+
+/*
+ * jsdom does not resolve custom properties, so toHaveStyle() normalises `var(--x, y)`
+ * to the empty string and cannot compare it. These buttons now take their ink from
+ * `--pie-text`, so assert against the rule emotion emitted for the element's class.
+ */
+const declaredColor = (el) =>
+  Array.from(document.querySelectorAll('style'))
+    .flatMap((tag) => Array.from(tag.sheet?.cssRules || []))
+    .filter((rule) => Array.from(el.classList).some((c) => rule.selectorText?.includes(`.${c}`)))
+    .map((rule) => rule.style?.color)
+    .find(Boolean);
 
 describe('RawButton', () => {
   it('renders without crashing', () => {
@@ -58,7 +71,7 @@ describe('RawButton', () => {
       </RawButton>,
     );
     const button = getByText('Active');
-    expect(button).toHaveStyle({ color: 'black' });
+    expect(declaredColor(button)).toBe(color.text());
   });
 
   it('applies disabled style when disabled is true', () => {
@@ -196,7 +209,7 @@ describe('RawMarkButton', () => {
       </RawMarkButton>,
     );
     const button = getByText('B');
-    expect(button).toHaveStyle({ color: 'black' });
+    expect(declaredColor(button)).toBe(color.text());
   });
 
   it('has aria-label from label prop', () => {

--- a/packages/editable-html-tip-tap/src/components/common/toolbar-buttons.jsx
+++ b/packages/editable-html-tip-tap/src/components/common/toolbar-buttons.jsx
@@ -2,11 +2,12 @@ import React from 'react';
 import debug from 'debug';
 import { styled } from '@mui/material/styles';
 import PropTypes from 'prop-types';
+import { color } from '@pie-lib/render-ui';
 
 const StyledButton = styled('button', {
   shouldForwardProp: (prop) => !['active', 'disabled', 'extraStyles'].includes(prop),
-})(({ theme, active, disabled }) => ({
-  color: active ? 'black' : 'grey',
+})(({ active, disabled }) => ({
+  color: active ? color.text() : color.disabled(),
   display: 'inline-flex',
   padding: '2px',
   background: 'none',
@@ -18,10 +19,11 @@ const StyledButton = styled('button', {
     height: '24px',
   },
   '&:hover': {
-    color: disabled ? 'grey' : 'black',
+    color: disabled ? color.disabled() : color.text(),
   },
   '&:focus': {
-    outline: `2px solid ${theme.palette.grey[700]}`,
+    // See MenuBar: the focus ring takes the registered focus token, not a grey.
+    outline: `2px solid ${color.buttonFocusOutline()}`,
   },
   ...(disabled && {
     opacity: 0.7,

--- a/packages/editable-html-tip-tap/src/components/respArea/MathTemplated.jsx
+++ b/packages/editable-html-tip-tap/src/components/respArea/MathTemplated.jsx
@@ -3,10 +3,16 @@ import PropTypes from 'prop-types';
 import { NodeViewWrapper } from '@tiptap/react';
 import { mq } from '@pie-lib/math-input';
 import { styled } from '@mui/material/styles';
+import { color } from '@pie-lib/render-ui';
 
 const StyledSpanContainer = styled('span')(() => ({
   display: 'inline-flex',
-  border: '1px solid #C0C3CF',
+  /*
+   * #C0C3CF is `--pie-blue-grey-300`'s default value, but that token is a fill: it
+   * measures 1.00:1 against black-on-rose's own background. The box outline is what
+   * marks the response slot in running text, so it takes the stroke token instead.
+   */
+  border: `1px solid ${color.border()}`,
   margin: '1px 5px',
   cursor: 'pointer',
   alignItems: 'center',
@@ -16,11 +22,12 @@ const StyledSpanContainer = styled('span')(() => ({
   height: 'fit-content',
 }));
 
-const StyledResponseBox = styled('div')(({ theme }) => ({
-  background: theme.palette.grey['A100'],
-  color: theme.palette.grey['A700'],
+const StyledResponseBox = styled('div')(() => ({
+  // Fill and ink move together so the label stays legible on whatever the fill becomes.
+  background: color.backgroundDark(),
+  color: color.text(),
   display: 'inline-flex',
-  borderRight: '2px solid #C0C3CF',
+  borderRight: `2px solid ${color.border()}`,
   boxSizing: 'border-box',
   overflow: 'hidden',
   fontSize: '12px',

--- a/packages/math-toolbar/src/done-button.jsx
+++ b/packages/math-toolbar/src/done-button.jsx
@@ -4,16 +4,20 @@ import IconButton from '@mui/material/IconButton';
 import Check from '@mui/icons-material/Check';
 import { styled } from '@mui/material/styles';
 import PropTypes from 'prop-types';
+import { color } from '@pie-lib/render-ui';
 
-const StyledIconButton = styled(IconButton)(({ theme, hideBackground }) => ({
+const StyledIconButton = styled(IconButton)(({ hideBackground }) => ({
   verticalAlign: 'top',
   width: '28px',
   height: '28px',
   color: '#00bb00',
   ...(hideBackground && {
-    backgroundColor: theme.palette.common.white,
+    // `--pie-white` inverts with the scheme where `common.white` did not, so the
+    // button keeps reading as raised against the toolbar instead of staying a
+    // white chip on a dark surface.
+    backgroundColor: color.white(),
     '&:hover': {
-      backgroundColor: theme.palette.grey[200],
+      backgroundColor: color.backgroundDark(),
     },
   }),
   '& .MuiIconButton-label': {

--- a/packages/render-ui/src/color.js
+++ b/packages/render-ui/src/color.js
@@ -38,6 +38,8 @@ export const defaults = {
   FOCUS_CHECKED_BORDER: '#1565C0',
   FOCUS_UNCHECKED: '#E0E0E0',
   FOCUS_UNCHECKED_BORDER: '#757575',
+  // the keyboard focus ring on a button or toolbar control
+  BUTTON_FOCUS_OUTLINE: '#3B82F6',
   // this is used for select text tokens
   BLUE_GREY100: '#F3F5F7',
   BLUE_GREY300: '#C0C3CF',
@@ -115,6 +117,7 @@ export const focusChecked = () => pv('focus-checked', defaults.FOCUS_CHECKED);
 export const focusCheckedBorder = () => pv('focus-checked-border', defaults.FOCUS_CHECKED_BORDER);
 export const focusUnchecked = () => pv('focus-unchecked', defaults.FOCUS_UNCHECKED);
 export const focusUncheckedBorder = () => pv('focus-unchecked-border', defaults.FOCUS_UNCHECKED_BORDER);
+export const buttonFocusOutline = () => pv('button-focus-outline', defaults.BUTTON_FOCUS_OUTLINE);
 
 export const blueGrey100 = () => pv('blue-grey-100', defaults.BLUE_GREY100);
 export const blueGrey300 = () => pv('blue-grey-300', defaults.BLUE_GREY300);
@@ -125,7 +128,8 @@ export const keypadButton = () => pv('keypad-button', defaults.KEYPAD_BUTTON);
 export const keypadButtonOperator = () => pv('keypad-button-operator', defaults.KEYPAD_BUTTON_OPERATOR);
 export const keypadEmptyPlaceholder = () => pv('keypad-empty-placeholder', defaults.KEYPAD_EMPTY_PLACEHOLDER);
 export const keypadButtonHover = () => pv('keypad-button-hover', defaults.KEYPAD_BUTTON_HOVER);
-export const keypadButtonOperatorHover = () => pv('keypad-button-operator-hover', defaults.KEYPAD_BUTTON_OPERATOR_HOVER);
+export const keypadButtonOperatorHover = () =>
+  pv('keypad-button-operator-hover', defaults.KEYPAD_BUTTON_OPERATOR_HOVER);
 export const keyBoardFocusIndicator = () => pv('keyboard-focus-indicator', defaults.KEY_BOARD_FOCUS_INDICATOR);
 export const buttonBorder = () => pv('button-border', defaults.BUTTON_BORDER);
 export const buttonHoverBg = () => pv('button-hover-bg', defaults.BUTTON_HOVER_BG);


### PR DESCRIPTION
## What

`theme.palette.grey[N]` does not follow `--pie-*`, so every one of those reads held a
fixed hex under every colour scheme. This moves the ten reads in `config-ui`,
`editable-html-tip-tap` and `math-toolbar` onto the `color.*()` accessors, and adds
`color.buttonFocusOutline()` for `--pie-button-focus-outline`.

Part of PIE-856. The `pie-elements` half is
pie-framework/pie-elements#3102, and both need to land before
`pie-elements-ng` can sync the generated files.

## Why these tokens

Measured against each scheme's own `--pie-background` across the ten schemes in
`pie-players` — `packages/theme/src/color-schemes.css`:

| role | token | worst ratio |
| --- | --- | --- |
| stroke, divider, connector | `--pie-border` | 3.23:1 |
| focus ring | `--pie-button-focus-outline` | 3.68:1 |
| text, interactive icon | `--pie-text` | 6.21:1 |
| disabled affordance | `--pie-disabled` | 3.17:1 |
| fill | `--pie-background-dark` | n/a — a fill belongs close to the page |

`--pie-border-light` is not used for strokes: it measures 1.53:1 in the default scheme.
`--pie-keyboard-focus-indicator` is not used for the focus rings even though
`color.keyBoardFocusIndicator()` exists — it is absent from the `pie-players` token
registry, so no scheme can reach it. `--pie-button-focus-outline` is
`canonical-semantic`/`active` there, which is why the new accessor points at it.

## Notable

The two editor focus rings were drawing themselves in `grey[700]` — 1.28:1 on
yellow-on-navy.

`settings-box` moves `background.paper` to `--pie-white` alongside its stroke. Both have
to move together: `background.paper` is MUI's `#fff` regardless of scheme, so tokenising
the stroke alone would put a scheme's border colour on a permanently white panel, and
under white-on-black `--pie-border` is `#ffffff` — the outline would vanish. `--pie-white`
inverts with the scheme, which is what `background.paper` was standing in for.

`#C0C3CF` in `MathTemplated` is `--pie-blue-grey-300`'s default value, but that token is
a fill and measures 1.00:1 against some schemes' backgrounds, so the response-slot
outline takes the stroke token instead.

## Tests

`packages/config-ui/src`, `packages/math-toolbar/src`,
`packages/editable-html-tip-tap/src` and `packages/render-ui/src`: 85 suites, 1278
passing. `eslint` at exact parity with `develop` — 0 errors, same 119 warnings, none new.

Two `toolbar-buttons` assertions changed. They pinned `color: 'black'`; jsdom does not
resolve custom properties, so `toHaveStyle` normalises `var(--pie-text, black)` to the
empty string and cannot compare it. They now read the declaration emotion emitted for
the element's class.
