### PR TITLE
fix(graphing): focus a new label even if its tool was remounted PIE-681

### DIFF
--- a/packages/graphing/src/__tests__/graph.test.jsx
+++ b/packages/graphing/src/__tests__/graph.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render } from '@pie-lib/test-utils';
+import { act, fireEvent, render } from '@pie-lib/test-utils';
 import { graphProps } from './utils';
 import Graph, { removeBuildingToolIfCurrentToolDiffers } from '../graph';
 import { toolsArr } from '../tools';
@@ -717,5 +717,61 @@ describe('Graph', () => {
 
       expect(container.querySelector('#marks')).toBeInTheDocument();
     });
+  });
+});
+
+describe('label focus', () => {
+  // the marks are owned by the host and come back from a model save asynchronously; a mark that
+  // shows up in front of the labelled one changes its key, so the tool that handled the click is
+  // remounted and the editingLabel it set is gone before the label input ever renders
+  const Host = ({ shiftMarks }) => {
+    const [marks, setMarks] = React.useState([{ type: 'point', x: 2, y: 2 }]);
+
+    return (
+      <Graph
+        tools={toolsArr}
+        marks={marks}
+        labelModeEnabled={true}
+        onChangeMarks={(next) =>
+          setTimeout(() => setMarks(shiftMarks ? [{ type: 'point', x: 5, y: 5 }, ...next] : next), 30)
+        }
+        domain={{ min: 0, max: 10, step: 1 }}
+        range={{ min: 0, max: 10, step: 1 }}
+        size={{ width: 400, height: 400 }}
+        {...graphProps(0, 10, 0, 10)}
+      />
+    );
+  };
+
+  const clickPoint = (container) => {
+    const circle = container.querySelector('circle');
+
+    fireEvent.mouseDown(circle, { button: 0 });
+    fireEvent.mouseUp(circle, { button: 0 });
+    fireEvent.click(circle, { button: 0 });
+    act(() => jest.advanceTimersByTime(200));
+  };
+
+  beforeEach(() => jest.useFakeTimers());
+  afterEach(() => jest.useRealTimers());
+
+  it('focuses the label that was just added', () => {
+    const { container } = render(<Host />);
+
+    clickPoint(container);
+
+    const input = container.querySelector('foreignObject input');
+    expect(input).not.toBe(null);
+    expect(document.activeElement).toBe(input);
+  });
+
+  it('focuses the label even if the tool was remounted before it rendered', () => {
+    const { container } = render(<Host shiftMarks={true} />);
+
+    clickPoint(container);
+
+    const input = container.querySelector('foreignObject input');
+    expect(input).not.toBe(null);
+    expect(document.activeElement).toBe(input);
   });
 });

--- a/packages/graphing/src/__tests__/mark-label.test.jsx
+++ b/packages/graphing/src/__tests__/mark-label.test.jsx
@@ -75,8 +75,8 @@ describe('MarkLabel - editing', () => {
       expect(input.selectionEnd).toBe(2);
     });
 
-    it('does not focus the input when autoFocus is not set', () => {
-      const { input } = renderComponent();
+    it('does not focus the input of an existing label when autoFocus is not set', () => {
+      const { input } = renderComponent({ mark: { x: 1, y: 1, label: 'A' } });
 
       expect(document.activeElement).not.toBe(input);
     });
@@ -85,6 +85,38 @@ describe('MarkLabel - editing', () => {
       const { input } = renderComponent({ autoFocus: true, disabled: true });
 
       expect(document.activeElement).not.toBe(input);
+    });
+
+    it('does not focus the input of a disabled mark', () => {
+      const { input } = renderComponent({ autoFocus: true, mark: { x: 1, y: 1, label: '', disabled: true } });
+
+      expect(document.activeElement).not.toBe(input);
+    });
+
+    // the focus can go away without this component hearing about it - the input node gets replaced
+    // by a render higher up, so no blur is fired and autoFocus is still on
+    it('takes the focus back on the next render while it is still being edited', () => {
+      const { input, rerenderWith } = renderComponent({ autoFocus: true, mark: { x: 1, y: 1, label: 'A' } });
+
+      expect(document.activeElement).toBe(input);
+
+      input.blur();
+      expect(document.activeElement).not.toBe(input);
+
+      rerenderWith({ mark: { x: 1, y: 1, label: 'A' } });
+
+      expect(document.activeElement).toBe(input);
+    });
+
+    it('leaves the caret where the user put it while the input has the focus', () => {
+      const { input, rerenderWith } = renderComponent({ autoFocus: true, mark: { x: 1, y: 1, label: 'ABC' } });
+
+      input.setSelectionRange(1, 1);
+
+      rerenderWith({ mark: { x: 1, y: 1, label: 'ABC' } });
+
+      expect(document.activeElement).toBe(input);
+      expect(input.selectionStart).toBe(1);
     });
 
     it('focuses the input once it is no longer disabled', () => {
@@ -115,6 +147,68 @@ describe('MarkLabel - editing', () => {
 
       expect(second).not.toBe(first);
       expect(document.activeElement).toBe(second);
+    });
+  });
+
+  // the tool asks for the focus with autoFocus, but its state can be gone before the input renders:
+  // the marks come back from the host asynchronously and can remount the tool. An empty label in
+  // label mode is a label the user has just added, so the input can tell on its own.
+  describe('a label that was just added', () => {
+    it('focuses itself without the tool asking', () => {
+      const { input } = renderComponent({ mark: { x: 1, y: 1, label: '' } });
+
+      expect(document.activeElement).toBe(input);
+    });
+
+    it('focuses itself again when it is remounted before it was typed into', () => {
+      const props = {
+        onChange,
+        onBlur,
+        inputRef: jest.fn(),
+        mark: { x: 1, y: 1, label: '' },
+        graphProps: getGraphProps(0, 10, 0, 10),
+      };
+      const { container, rerender } = render(<MarkLabel key="first" {...props} />);
+      const first = input(container);
+
+      rerender(<MarkLabel key="second" {...props} />);
+      const second = input(container);
+
+      expect(second).not.toBe(first);
+      expect(document.activeElement).toBe(second);
+    });
+
+    it('stops chasing the focus once it has been left', () => {
+      const { input, rerenderWith } = renderComponent({ mark: { x: 1, y: 1, label: '' } });
+
+      expect(document.activeElement).toBe(input);
+
+      input.blur();
+      rerenderWith({ mark: { x: 1, y: 1, label: '' } });
+
+      expect(document.activeElement).not.toBe(input);
+    });
+
+    // outside of label mode the input is disabled, which is how an empty label that was loaded with
+    // the item is told apart from one the user has just added - label mode always starts off
+    it('is not focused while label mode is off', () => {
+      const { input } = renderComponent({ disabled: true, mark: { x: 1, y: 1, label: '' } });
+
+      expect(document.activeElement).not.toBe(input);
+    });
+
+    it('is not focused when label mode is turned on afterwards', () => {
+      const { rerenderWith, container } = renderComponent({ disabled: true, mark: { x: 1, y: 1, label: '' } });
+
+      rerenderWith({ disabled: false });
+
+      expect(document.activeElement).not.toBe(input(container));
+    });
+
+    it('is not focused when the mark is disabled', () => {
+      const { input } = renderComponent({ mark: { x: 1, y: 1, label: '', disabled: true } });
+
+      expect(document.activeElement).not.toBe(input);
     });
   });
 

--- a/packages/graphing/src/mark-label.jsx
+++ b/packages/graphing/src/mark-label.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import { styled, useTheme } from '@mui/material/styles';
 import AutosizeInput from 'react-input-autosize';
@@ -130,8 +130,14 @@ LabelInput.propTypes = {
 };
 
 export const MarkLabel = (props) => {
+  // the node is kept in a ref as well as in the state: the state is needed to reposition the label
+  // once it has a size, the ref is what the focus is asserted on - it is never a render behind
+  const inputNode = useRef(null);
   const [input, setInput] = useState(null);
-  const _ref = useCallback((node) => setInput(node));
+  const _ref = useCallback((node) => {
+    inputNode.current = node;
+    setInput(node);
+  }, []);
   const theme = useTheme();
 
   const { mark, graphProps, disabled, autoFocus, inputRef: externalInputRef } = props;
@@ -139,11 +145,21 @@ export const MarkLabel = (props) => {
   const [label, setLabel] = useState(mark.label);
   const { correctness, correctnesslabel, correctlabel } = mark;
 
-  const isFocused = () => !!input && typeof document !== 'undefined' && document.activeElement === input;
+  const isFocused = () =>
+    !!inputNode.current && typeof document !== 'undefined' && document.activeElement === inputNode.current;
+
+  // A label that has just been added is empty and its input is enabled - label mode has to be on
+  // for that to happen and it always starts off, so a mark that was loaded with an empty label
+  // cannot grab the focus. This is read from the mark rather than taken from the autoFocus prop
+  // because the tool that asked for the label can be remounted by the marks coming back from the
+  // host (async model save) before the input ever renders, and its autoFocus goes with it.
+  const isNewLabel = useRef(mark.label === '' && !disabled && !mark.disabled);
 
   const onChange = (e) => setLabel(e.target.value);
 
   const handleBlur = useCallback(() => {
+    isNewLabel.current = false;
+
     if (label === '') {
       props.onChange('');
     }
@@ -175,22 +191,33 @@ export const MarkLabel = (props) => {
   }, [debouncedLabel]);
 
   // A label that has just been added has to be focused so that it can be typed into right away.
-  // This also re-focuses the input if it gets remounted while it is being edited - saving the model
-  // is done by the host (api call) and the model that comes back can replace the input node.
+  // This runs after every render on purpose - there is no reliable single moment to focus at:
+  // the input shows up whenever the mark comes back from the (async) model save, and a remount
+  // of the input (same save, replaced node) drops the focus without this component being told.
+  // Asserting the focus on every render is what makes it stick; it is a no-op once the input has
+  // it, so the caret the user placed is left alone.
   useEffect(() => {
-    if (!autoFocus || !input || disabled || isFocused()) {
+    const node = inputNode.current;
+
+    // node.disabled, not the disabled prop: a disabled input silently ignores focus()
+    if ((!autoFocus && !isNewLabel.current) || !node || node.disabled || isFocused()) {
       return;
     }
 
-    input.focus();
+    node.focus();
+
+    // a new label is focused once, so it cannot fight over the focus with another one
+    if (isFocused()) {
+      isNewLabel.current = false;
+    }
 
     // keep the caret at the end, otherwise typing continues in front of the existing label
-    const caret = (input.value || '').length;
+    const caret = (node.value || '').length;
 
-    if (input.setSelectionRange) {
-      input.setSelectionRange(caret, caret);
+    if (node.setSelectionRange) {
+      node.setSelectionRange(caret, caret);
     }
-  }, [autoFocus, input, disabled]);
+  });
 
   const rect = input ? input.getBoundingClientRect() : { width: 0, height: 0 };
   const pos = position(graphProps, mark, rect);


### PR DESCRIPTION
The tool that handles the click keeps the label it is editing in its state, but the mark travels to the host and comes back asynchronously - a mark that shows up in front of it changes its key, the tool remounts and autoFocus is already false by the time the label input renders.

MarkLabel now tells on its own: an empty label with an enabled input can only come from the user just having clicked to add one, since label mode has to be on for the input to be enabled and label mode always starts off. That signal rides along with the mark, so it survives the round trip and the remount.

It is captured on mount and cleared after the first focus and on blur, so an empty label loaded with the item, or one the user has left, does not pull the focus. The focus is also asserted after every render now instead of only when autoFocus/input/disabled change, so a node that renders late or loses the focus without being blurred gets it back.