### PR TITLE
fix(render-ui)!: scope PreviewPrompt to its own node instead of a shared id PIE-927

### DIFF
--- a/packages/render-ui/src/__tests__/preview-prompt.test.jsx
+++ b/packages/render-ui/src/__tests__/preview-prompt.test.jsx
@@ -345,10 +345,30 @@ describe('PreviewPrompt - Extended Tests', () => {
   });
 
   describe('accessibility', () => {
-    it('should have preview-prompt id for accessibility', () => {
-      render(<PreviewPrompt prompt="Accessible text" />);
-      const element = document.getElementById('preview-prompt');
-      expect(element).toBeInTheDocument();
+    it('should mark the container with the stable preview-prompt class', () => {
+      const { container } = render(<PreviewPrompt prompt="Accessible text" />);
+      expect(container.firstChild).toHaveClass('preview-prompt');
+    });
+
+    it('should not emit an id on the container', () => {
+      const { container } = render(<PreviewPrompt prompt="Accessible text" />);
+      expect(container.firstChild).not.toHaveAttribute('id');
+    });
+
+    it('should leave no duplicate ids when a page renders many prompts', () => {
+      const { container } = render(
+        <div>
+          <PreviewPrompt prompt="Item 1" />
+          <PreviewPrompt prompt="Item 2" />
+          <PreviewPrompt prompt="Item 3" />
+          <PreviewPrompt prompt="Item 4" />
+          <PreviewPrompt prompt="Item 5" />
+        </div>,
+      );
+
+      const ids = Array.from(container.querySelectorAll('[id]')).map((el) => el.id);
+
+      expect(ids).toEqual(Array.from(new Set(ids)));
     });
 
     it('should preserve semantic HTML', () => {
@@ -374,6 +394,39 @@ describe('PreviewPrompt - Extended Tests', () => {
       expect(screen.getByText('First prompt')).toBeInTheDocument();
       expect(screen.getByText('Second prompt')).toBeInTheDocument();
       expect(screen.getByText('Third prompt')).toBeInTheDocument();
+    });
+
+    it('should typeset each instance with its own node rather than the first prompt on the page', () => {
+      renderMath.mockClear();
+
+      render(
+        <div>
+          <PreviewPrompt prompt="First prompt" />
+          <PreviewPrompt prompt="Second prompt" />
+          <PreviewPrompt prompt="Third prompt" />
+        </div>,
+      );
+
+      const typesetNodes = renderMath.mock.calls.map(([node]) => node);
+
+      expect(typesetNodes).toHaveLength(3);
+      expect(new Set(typesetNodes).size).toBe(3);
+      expect(typesetNodes.map((node) => node.textContent)).toEqual(['First prompt', 'Second prompt', 'Third prompt']);
+    });
+
+    it('should align images within each instance independently', () => {
+      const { container } = render(
+        <div>
+          <PreviewPrompt prompt='<img src="a.png" alignment="center" />' />
+          <PreviewPrompt prompt='<img src="b.png" alignment="right" />' />
+        </div>,
+      );
+
+      const wrappers = container.querySelectorAll('.preview-prompt > div');
+
+      expect(wrappers).toHaveLength(2);
+      expect(wrappers[0].style.justifyContent).toBe('center');
+      expect(wrappers[1].style.justifyContent).toBe('flex-end');
     });
   });
 });

--- a/packages/render-ui/src/preview-prompt.jsx
+++ b/packages/render-ui/src/preview-prompt.jsx
@@ -60,6 +60,10 @@ const StyledPromptContainer = styled('div')(({ theme, tagName }) => ({
 const NEWLINE_BLOCK_REGEX = /\\embed\{newLine\}\[\]/g;
 const NEWLINE_LATEX = '\\newline ';
 
+// stable hook for 'is this node inside a prompt' checks - a class rather than an id,
+// so it stays valid when a page renders more than one prompt
+const PROMPT_CLASS = 'preview-prompt';
+
 export class PreviewPrompt extends Component {
   static propTypes = {
     prompt: PropTypes.string,
@@ -77,6 +81,8 @@ export class PreviewPrompt extends Component {
   static defaultProps = {
     onClick: () => {},
   };
+
+  promptRef = React.createRef();
 
   parsedText = (text) => {
     const { customAudioButton } = this.props;
@@ -213,59 +219,61 @@ export class PreviewPrompt extends Component {
   }
 
   renderMathContent() {
-    const container = document.getElementById('preview-prompt');
+    const container = this.promptRef.current;
     if (container && typeof renderMath === 'function') {
       renderMath(container);
     }
   }
 
   alignImages() {
-    const previewPrompts = document.querySelectorAll('#preview-prompt');
+    const previewPrompt = this.promptRef.current;
 
-    previewPrompts.forEach((previewPrompt) => {
-      const images = previewPrompt.getElementsByTagName('img');
+    if (!previewPrompt) {
+      return;
+    }
 
-      if (images && images.length) {
-        for (let image of images) {
-          if (image.attributes && image.attributes.alignment && image.attributes.alignment.value) {
-            const alignment = image.attributes.alignment.value;
-            const justifyContent =
-              alignment === 'center' ? 'center' : alignment === 'right' ? 'flex-end' : 'flex-start';
+    const images = previewPrompt.getElementsByTagName('img');
 
-            const parentNode = image.parentElement;
+    if (images && images.length) {
+      for (let image of images) {
+        if (image.attributes && image.attributes.alignment && image.attributes.alignment.value) {
+          const alignment = image.attributes.alignment.value;
+          const justifyContent =
+            alignment === 'center' ? 'center' : alignment === 'right' ? 'flex-end' : 'flex-start';
 
-            if (
-              parentNode.tagName === 'DIV' &&
-              parentNode.style.display === 'flex' &&
-              parentNode.style.width === '100%'
-            ) {
-              parentNode.style.justifyContent = justifyContent;
-            } else {
-              const div = document.createElement('div');
-              div.style.display = 'flex';
-              div.style.width = '100%';
-              div.style.justifyContent = justifyContent;
+          const parentNode = image.parentElement;
 
-              const copyImage = image.cloneNode(true);
-              div.appendChild(copyImage);
-              parentNode.replaceChild(div, image);
-            }
+          if (
+            parentNode.tagName === 'DIV' &&
+            parentNode.style.display === 'flex' &&
+            parentNode.style.width === '100%'
+          ) {
+            parentNode.style.justifyContent = justifyContent;
+          } else {
+            const div = document.createElement('div');
+            div.style.display = 'flex';
+            div.style.width = '100%';
+            div.style.justifyContent = justifyContent;
+
+            const copyImage = image.cloneNode(true);
+            div.appendChild(copyImage);
+            parentNode.replaceChild(div, image);
           }
         }
       }
-    });
+    }
   }
 
   render() {
     const { prompt, tagName, className, onClick, defaultClassName } = this.props;
     // legend tag was added once with accessibility tasks, we need extra style to make it work with images alignment
     const legendClass = tagName === 'legend' ? 'legend' : '';
-    const customClasses = `${className || ''} ${defaultClassName || ''} ${legendClass}`.trim();
+    const customClasses = `${className || ''} ${defaultClassName || ''} ${legendClass} ${PROMPT_CLASS}`.trim();
 
     return (
       <StyledPromptContainer
         as={tagName || 'div'}
-        id={'preview-prompt'}
+        ref={this.promptRef}
         onClick={onClick}
         className={customClasses}
         tagName={tagName}


### PR DESCRIPTION
https://illuminate.atlassian.net/browse/PIE-927

PreviewPrompt located its own DOM node by searching the whole document for #preview-prompt, but every prompt on a page emitted that same id. getElementById returns the first match, so on a 5-item page 28 of 30 typeset requests resolved to item 1's prompt and items 2-5 were never typeset at all. querySelectorAll returns every match, so each instance additionally re-aligned every other prompt's images, making that work O(N^2) in item count.

Both lookups now read a ref to the component's own container and can no longer escape the instance's subtree. The hardcoded id is removed: duplicate ids in one document are invalid HTML and break aria-labelledby / aria-describedby and label-for wiring. A stable `preview-prompt` class replaces it as the hook for "is this node inside a prompt" checks, which is a kind test rather than an identity one.

No replacement id is needed. Where the prompt genuinely labels a groNo replacement id is nnatively, rendered as a <legend> inside <fieldset>, and nothing in pie-lib or pie-elements points an aria id-reference at it.

BREAKING CHANGE: PreviewPrompt no longer renders id="preview-prompt". Consumers matching on that id must match the `.preview-prompt` class instead, e.g. audio.closest('#preview-prompt') becomes audio.closest('.preview-prompt'). Affects 5 pie-elements packages: multiple-choice, categorize, drag-in-the-blank, hotspot, image-cloze-association.